### PR TITLE
Use u64 instead of i64 for the type for recorded values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
+
+# JetBrains products
+.idea
+*.iml

--- a/benchmarks/all.rs
+++ b/benchmarks/all.rs
@@ -15,9 +15,9 @@ mod inner {
     use hdrsample::Histogram;
     use std::time::Duration;
 
-    const TRACKABLE_MAX: i64 = 3600 * 1000 * 1000; // e.g. for 1 hr in usec units
+    const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000; // e.g. for 1 hr in usec units
     const SIGFIG: u32 = 3;
-    const TEST_VALUE_LEVEL: i64 = 12340;
+    const TEST_VALUE_LEVEL: u64 = 12340;
 
     pub fn main() {
         let mut h = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();

--- a/benchmarks/busy.rs
+++ b/benchmarks/busy.rs
@@ -1,9 +1,9 @@
 extern crate hdrsample;
 use hdrsample::Histogram;
 
-const TRACKABLE_MAX: i64 = 3600 * 1000 * 1000; // e.g. for 1 hr in usec units
+const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000; // e.g. for 1 hr in usec units
 const SIGFIG: u32 = 3;
-const TEST_VALUE_LEVEL: i64 = 12340;
+const TEST_VALUE_LEVEL: u64 = 12340;
 
 fn main() {
     let mut h = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();

--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -6,6 +6,7 @@ use iterators::{HistogramIterator, PickyIterator};
 pub struct Iter<'a, T: 'a + Counter> {
     hist: &'a Histogram<T>,
 
+    // > 0
     valueUnitsPerBucket: u64,
     currentStepHighestValueReportingLevel: u64,
     currentStepLowestValueReportingLevel: u64,
@@ -16,10 +17,12 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
     pub fn new(hist: &'a Histogram<T>,
                valueUnitsPerBucket: u64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
+        assert!(valueUnitsPerBucket > 0);
         HistogramIterator::new(hist,
                                Iter {
                                    hist: hist,
                                    valueUnitsPerBucket: valueUnitsPerBucket,
+                                   // won't underflow because valueUnitsPerBucket > 0
                                    currentStepHighestValueReportingLevel: valueUnitsPerBucket - 1,
                                    currentStepLowestValueReportingLevel:
                                        hist.lowest_equivalent(valueUnitsPerBucket - 1),

--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -6,15 +6,15 @@ use iterators::{HistogramIterator, PickyIterator};
 pub struct Iter<'a, T: 'a + Counter> {
     hist: &'a Histogram<T>,
 
-    valueUnitsPerBucket: i64,
-    currentStepHighestValueReportingLevel: i64,
-    currentStepLowestValueReportingLevel: i64,
+    valueUnitsPerBucket: u64,
+    currentStepHighestValueReportingLevel: u64,
+    currentStepLowestValueReportingLevel: u64,
 }
 
 impl<'a, T: 'a + Counter> Iter<'a, T> {
     /// Construct a new linear iterator. See `Histogram::iter_linear` for details.
     pub fn new(hist: &'a Histogram<T>,
-               valueUnitsPerBucket: i64)
+               valueUnitsPerBucket: u64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
         HistogramIterator::new(hist,
                                Iter {

--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -17,7 +17,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
     pub fn new(hist: &'a Histogram<T>,
                valueUnitsPerBucket: u64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
-        assert!(valueUnitsPerBucket > 0);
+        assert!(valueUnitsPerBucket > 0, "valueUnitsPerBucket must be > 0");
         HistogramIterator::new(hist,
                                Iter {
                                    hist: hist,

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -9,14 +9,14 @@ pub struct Iter<'a, T: 'a + Counter> {
     nextValueReportingLevel: f64,
     logBase: f64,
 
-    currentStepLowestValueReportingLevel: i64,
-    currentStepHighestValueReportingLevel: i64,
+    currentStepLowestValueReportingLevel: u64,
+    currentStepHighestValueReportingLevel: u64,
 }
 
 impl<'a, T: 'a + Counter> Iter<'a, T> {
     /// Construct a new logarithmic iterator. See `Histogram::iter_log` for details.
     pub fn new(hist: &'a Histogram<T>,
-               valueUnitsInFirstBucket: i64,
+               valueUnitsInFirstBucket: u64,
                logBase: f64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
         HistogramIterator::new(hist,
@@ -37,7 +37,7 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         let val = self.hist.value_for(index);
         if val >= self.currentStepLowestValueReportingLevel || index == self.hist.last() {
             self.nextValueReportingLevel *= self.logBase;
-            self.currentStepHighestValueReportingLevel = self.nextValueReportingLevel as i64 - 1;
+            self.currentStepHighestValueReportingLevel = self.nextValueReportingLevel as u64 - 1;
             self.currentStepLowestValueReportingLevel = self.hist
                 .lowest_equivalent(self.currentStepHighestValueReportingLevel);
             true
@@ -51,7 +51,7 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // reached this point), then we are not yet done iterating (we want to iterate until we are
         // no longer on a value that has a count, rather than util we first reach the last value
         // that has a count. The difference is subtle but important)...
-        self.hist.lowest_equivalent(self.nextValueReportingLevel as i64) <
+        self.hist.lowest_equivalent(self.nextValueReportingLevel as u64) <
         self.hist.value_for(next_index)
     }
 }

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -21,8 +21,8 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
                valueUnitsInFirstBucket: u64,
                logBase: f64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
-        assert!(valueUnitsInFirstBucket > 0);
-        assert!(logBase > 1.0);
+        assert!(valueUnitsInFirstBucket > 0, "valueUnitsPerBucket must be > 0");
+        assert!(logBase > 1.0, "logBase must be > 1.0");
         HistogramIterator::new(hist,
                                Iter {
                                    hist: hist,

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -6,7 +6,9 @@ use iterators::{HistogramIterator, PickyIterator};
 pub struct Iter<'a, T: 'a + Counter> {
     hist: &'a Histogram<T>,
 
+    // > 1.0
     nextValueReportingLevel: f64,
+    // > 1.0
     logBase: f64,
 
     currentStepLowestValueReportingLevel: u64,
@@ -19,6 +21,8 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
                valueUnitsInFirstBucket: u64,
                logBase: f64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
+        assert!(valueUnitsInFirstBucket > 0);
+        assert!(logBase > 1.0);
         HistogramIterator::new(hist,
                                Iter {
                                    hist: hist,
@@ -36,7 +40,9 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
     fn pick(&mut self, index: usize, _: u64) -> bool {
         let val = self.hist.value_for(index);
         if val >= self.currentStepLowestValueReportingLevel || index == self.hist.last() {
+            // implies logBase must be > 1.0
             self.nextValueReportingLevel *= self.logBase;
+            // won't underflow since nextValueReportingLevel starts > 0 and only grows
             self.currentStepHighestValueReportingLevel = self.nextValueReportingLevel as u64 - 1;
             self.currentStepLowestValueReportingLevel = self.hist
                 .lowest_equivalent(self.currentStepHighestValueReportingLevel);
@@ -52,6 +58,6 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // no longer on a value that has a count, rather than util we first reach the last value
         // that has a count. The difference is subtle but important)...
         self.hist.lowest_equivalent(self.nextValueReportingLevel as u64) <
-        self.hist.value_for(next_index)
+            self.hist.value_for(next_index)
     }
 }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -61,7 +61,7 @@ impl<'a, T: Counter, P: PickyIterator<T>> HistogramIterator<'a, T, P> {
     }
 
     // (value, percentile, count-for-value, count-for-step)
-    fn current(&self) -> (i64, f64, T, T) {
+    fn current(&self) -> (u64, f64, T, T) {
         let value = self.hist.highest_equivalent(self.hist.value_for(self.currentIndex));
         let perc = 100.0 * self.totalCountToIndex.to_f64().unwrap() /
                    self.hist.count().to_f64().unwrap();
@@ -74,7 +74,7 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
     where T: Counter,
           P: PickyIterator<T>
 {
-    type Item = (i64, f64, T, T);
+    type Item = (u64, f64, T, T);
     fn next(&mut self) -> Option<Self::Item> {
         // here's the deal: we are iterating over all the indices in the histogram's .count array.
         // however, most of those values (especially towards the end) will be zeros, which the

--- a/tests/auto_resize.rs
+++ b/tests/auto_resize.rs
@@ -9,19 +9,24 @@ use hdrsample::Histogram;
 #[test]
 fn histogram_autosizing_edges() {
     let mut histogram = Histogram::<u64>::new(3).unwrap();
-    histogram += (1i64 << 62) - 1;
+    histogram += (1u64 << 62) - 1;
     assert_eq!(histogram.buckets(), 52);
     assert_eq!(histogram.len(), 54272);
-    histogram += i64::max_value();
-    assert_eq!(histogram.buckets(), 53);
-    assert_eq!(histogram.len(), 55296);
+    histogram += u64::max_value();
+    assert_eq!(histogram.buckets(), 54);
+    // unit magnitude = floor(log_2 (1 / 2)) = 0
+    // sub bucket count magnitude = floor(log_2 (2 * 10^3)) = 10
+    // sub bucket half count mag = 9
+    // sub bucket count = 2^(sbhcm + 1) = 2^9 = 1024
+    // total array size = (54 + 1) * (sub bucket count / 2) = 56320
+    assert_eq!(histogram.len(), 56320);
 }
 
 #[test]
 fn histogram_autosizing() {
     let mut histogram = Histogram::<u64>::new(3).unwrap();
     for i in 0..63 {
-        histogram += 1i64 << i;
+        histogram += 1u64 << i;
     }
     assert_eq!(histogram.buckets(), 53);
     assert_eq!(histogram.len(), 55296);
@@ -32,18 +37,18 @@ fn autosizing_add() {
     let mut histogram1 = Histogram::<u64>::new(2).unwrap();
     let mut histogram2 = Histogram::<u64>::new(2).unwrap();
 
-    histogram1 += 1000i64;
-    histogram1 += 1000000000i64;
+    histogram1 += 1000u64;
+    histogram1 += 1000000000u64;
 
     histogram2 += &histogram1;
-    assert!(histogram2.equivalent(histogram2.max(), 1000000000i64));
+    assert!(histogram2.equivalent(histogram2.max(), 1000000000u64));
 }
 
 #[test]
 fn autosizing_across_continuous_range() {
     let mut histogram = Histogram::<u64>::new(2).unwrap();
 
-    for i in 0..10000000i64 {
+    for i in 0..10000000u64 {
         histogram += i;
     }
 }

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -29,10 +29,10 @@ struct Loaded {
     scaled_post: Histogram<u64>,
 }
 
-const TRACKABLE_MAX: i64 = 3600 * 1000 * 1000;
+const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
 const SIGFIG: u32 = 3;
-const EINTERVAL: i64 = 10000; /* 10 msec expected EINTERVAL */
-const SCALEF: i64 = 512;
+const EINTERVAL: u64 = 10000; /* 10 msec expected EINTERVAL */
+const SCALEF: u64 = 512;
 
 fn load_histograms() -> Loaded {
     let mut hist = Histogram::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
@@ -193,7 +193,7 @@ fn percentiles() {
 
 #[test]
 fn large_percentile() {
-    let largestValue = 1000000000000i64;
+    let largestValue = 1000000000000u64;
     let mut h = Histogram::<u64>::new_with_max(largestValue, 5).unwrap();
     h += largestValue;
     assert!(h.value_at_percentile(100.0) > 0);
@@ -204,7 +204,7 @@ fn percentile_atorbelow() {
     let Loaded { hist, raw, .. } = load_histograms();
     assert_near!(99.99, raw.percentile_below(5000), 0.0001);
     assert_near!(50.0, hist.percentile_below(5000), 0.0001);
-    assert_near!(100.0, hist.percentile_below(100000000i64), 0.0001);
+    assert_near!(100.0, hist.percentile_below(100000000u64), 0.0001);
 }
 
 #[test]

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -34,9 +34,9 @@ fn verify_max<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) -> bool {
     }
 }
 
-const TRACKABLE_MAX: i64 = 3600 * 1000 * 1000;
+const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
 const SIGFIG: u32 = 3;
-const TEST_VALUE_LEVEL: i64 = 4;
+const TEST_VALUE_LEVEL: u64 = 4;
 
 #[test]
 fn construction_arg_ranges() {


### PR DESCRIPTION
This will make it easier to port my tests over, since those all use unsigned values, and value has to be non-negative anyway. This diff is mostly pretty mechanical; 95% of it is just making obvious changes to keep the compiler happy.

If you'd prefer I could submit this (and future) PRs to a different (non-master) branch if you'd like to accumulate this stuff elsewhere, though I don't plan on ever making a PR that would leave master in a broken state.