### PR TITLE
Use u64 instead of T as the type for aggregated counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
+
+# JetBrains products
+.idea
+*.iml

--- a/src/iterators/all.rs
+++ b/src/iterators/all.rs
@@ -13,7 +13,7 @@ impl Iter {
 }
 
 impl<T: Counter> PickyIterator<T> for Iter {
-    fn pick(&mut self, index: usize, _: T) -> bool {
+    fn pick(&mut self, index: usize, _: u64) -> bool {
         // have we visited before?
         if self.0.is_none() || self.0.unwrap() != index {
             self.0 = Some(index);

--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -28,7 +28,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, _: T) -> bool {
+    fn pick(&mut self, index: usize, _: u64) -> bool {
         let val = self.hist.value_for(index);
         if val >= self.currentStepLowestValueReportingLevel || index == self.hist.last() {
             self.currentStepHighestValueReportingLevel += self.valueUnitsPerBucket;

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -33,7 +33,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, _: T) -> bool {
+    fn pick(&mut self, index: usize, _: u64) -> bool {
         let val = self.hist.value_for(index);
         if val >= self.currentStepLowestValueReportingLevel || index == self.hist.last() {
             self.nextValueReportingLevel *= self.logBase;

--- a/src/iterators/percentile.rs
+++ b/src/iterators/percentile.rs
@@ -27,14 +27,13 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, running_total: T) -> bool {
+    fn pick(&mut self, index: usize, running_total: u64) -> bool {
         let count = &self.hist[index];
         if *count == T::zero() {
             return false;
         }
 
-        let currentPercentile = 100.0 * running_total.to_f64().unwrap() /
-                                self.hist.count().to_f64().unwrap();
+        let currentPercentile = 100.0 * running_total as f64 / self.hist.count() as f64;
         if currentPercentile < self.percentileLevelToIterateTo {
             return false;
         }
@@ -61,7 +60,7 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
 
     fn more(&mut self, _: usize) -> bool {
         // We want one additional last step to 100%
-        if !self.reachedLastRecordedValue && self.hist.count() != T::zero() {
+        if !self.reachedLastRecordedValue && self.hist.count() != 0 {
             self.percentileLevelToIterateTo = 100.0;
             self.reachedLastRecordedValue = true;
             true

--- a/src/iterators/recorded.rs
+++ b/src/iterators/recorded.rs
@@ -20,7 +20,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, _: T) -> bool {
+    fn pick(&mut self, index: usize, _: u64) -> bool {
         // is the count non-zero?
         if self.hist[index] != T::zero() {
             // have we visited before?

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -454,3 +454,37 @@ fn value_duplication() {
     assert!(histogram1 == histogram2,
             "histograms should be equal after re-recording");
 }
+
+#[test]
+fn total_count_exceeds_bucket_type() {
+    let mut h: Histogram<u8> = Histogram::new(3).unwrap();
+
+    for _ in 0..200 {
+        h.record(100).unwrap();
+    }
+
+
+    for _ in 0..200 {
+        h.record(100_000).unwrap();
+    }
+
+    assert_eq!(400, h.count());
+
+}
+
+#[test]
+fn value_at_percentile_internal_count_exceeds_bucket_type() {
+    let mut h: Histogram<u8> = Histogram::new(3).unwrap();
+
+    for _ in 0..200 {
+        h.record(100).unwrap();
+    }
+
+
+    for _ in 0..200 {
+        h.record(100_000).unwrap();
+    }
+
+    // we won't get back the original input because of bucketing
+    assert_eq!(h.highest_equivalent(100_000), h.value_at_percentile(100.0));
+}


### PR DESCRIPTION
While I work on the details of #1, here's a smaller fix I noticed.

With T as the total count, a Histogram<u8> will overflow on inserting the 256th value, even if no individual bucket overflows. This PR switches to using a u64 for the total count (and other associated local vars used in adding histograms, etc).