### PR TITLE
Use underscores in numeric literals

### DIFF
--- a/src/iterators/percentile.rs
+++ b/src/iterators/percentile.rs
@@ -52,8 +52,8 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
 
         let percentileReportingTicks =
             self.percentileTicksPerHalfDistance *
-            2f64.powi(((100.0 / (100.0 - self.percentileLevelToIterateTo)).ln() /
-                       2f64.ln()) as i32 + 1) as isize;
+            2_f64.powi(((100.0 / (100.0 - self.percentileLevelToIterateTo)).ln() /
+                       2_f64.ln()) as i32 + 1) as isize;
         self.percentileLevelToIterateTo += 100.0 / percentileReportingTicks as f64;
         true
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,22 +595,22 @@ impl<T: Counter> Histogram<T> {
         // maintain single unit resolution to 2x 10^decimalPoints.
 
         // largest value with single unit resolution
-        let largest = 2 * 10u64.pow(sigfig);
+        let largest = 2 * 10_u64.pow(sigfig);
 
-        let unitMagnitude = ((low as f64).log2() / 2f64.log2()).floor() as usize;
+        let unitMagnitude = ((low as f64).log2() / 2_f64.log2()).floor() as usize;
         let unitMagnitudeMask = (1 << unitMagnitude) - 1;
 
         // We need to maintain power-of-two subBucketCount (for clean direct indexing) that is
         // large enough to provide unit resolution to at least
         // largestValueWithSingleUnitResolution. So figure out
         // largestValueWithSingleUnitResolution's nearest power-of-two (rounded up), and use that:
-        let subBucketCountMagnitude = ((largest as f64).log2() / 2f64.log2()).ceil() as usize;
+        let subBucketCountMagnitude = ((largest as f64).log2() / 2_f64.log2()).ceil() as usize;
         let subBucketHalfCountMagnitude = if subBucketCountMagnitude > 1 {
             subBucketCountMagnitude
         } else {
             1
         } - 1;
-        let subBucketCount = 2usize.pow(subBucketHalfCountMagnitude as u32 + 1);
+        let subBucketCount = 2_usize.pow(subBucketHalfCountMagnitude as u32 + 1);
         let subBucketHalfCount = subBucketCount / 2;
         // subBucketCount is always at least 2, so subtraction won't underflow
         let subBucketMask = (subBucketCount as u64 - 1) << unitMagnitude;
@@ -959,7 +959,7 @@ impl<T: Counter> Histogram<T> {
     /// Get the lowest recorded value level in the histogram.
     /// If the histogram has no recorded values, the value returned will be 0.
     pub fn min(&self) -> u64 {
-        if self.totalCount == 0 || self[0usize] != T::zero() {
+        if self.totalCount == 0 || self[0_usize] != T::zero() {
             0
         } else {
             self.min_nz()
@@ -999,7 +999,7 @@ impl<T: Counter> Histogram<T> {
             return 0.0;
         }
 
-        self.iter_recorded().fold(0.0f64, |total, (v, _, c, _)| {
+        self.iter_recorded().fold(0.0_f64, |total, (v, _, c, _)| {
             total +
             self.median_equivalent(v) as f64 * c.to_f64().unwrap() / self.totalCount as f64
         })
@@ -1012,7 +1012,7 @@ impl<T: Counter> Histogram<T> {
         }
 
         let mean = self.mean();
-        let geom_dev_tot = self.iter_recorded().fold(0.0f64, |gdt, (v, _, _, sc)| {
+        let geom_dev_tot = self.iter_recorded().fold(0.0_f64, |gdt, (v, _, _, sc)| {
             let dev = self.median_equivalent(v) as f64 - mean;
             gdt + (dev * dev) * sc as f64
         });
@@ -1177,7 +1177,7 @@ impl<T: Counter> Histogram<T> {
         let bucketIndex = self.bucket_for(value);
         let subBucketIndex = self.sub_bucket_for(value, bucketIndex);
         // calculate distance to next value
-        1u64 <<
+        1_u64 <<
         (self.unitMagnitude +
          if subBucketIndex >= self.subBucketCount {
             bucketIndex + 1

--- a/tests/auto_resize.rs
+++ b/tests/auto_resize.rs
@@ -9,7 +9,7 @@ use hdrsample::Histogram;
 #[test]
 fn histogram_autosizing_edges() {
     let mut histogram = Histogram::<u64>::new(3).unwrap();
-    histogram += (1u64 << 62) - 1;
+    histogram += (1_u64 << 62) - 1;
     assert_eq!(histogram.buckets(), 52);
     assert_eq!(histogram.len(), 54272);
     histogram += u64::max_value();
@@ -26,7 +26,7 @@ fn histogram_autosizing_edges() {
 fn histogram_autosizing() {
     let mut histogram = Histogram::<u64>::new(3).unwrap();
     for i in 0..63 {
-        histogram += 1u64 << i;
+        histogram += 1_u64 << i;
     }
     assert_eq!(histogram.buckets(), 53);
     assert_eq!(histogram.len(), 55296);
@@ -37,18 +37,18 @@ fn autosizing_add() {
     let mut histogram1 = Histogram::<u64>::new(2).unwrap();
     let mut histogram2 = Histogram::<u64>::new(2).unwrap();
 
-    histogram1 += 1000u64;
-    histogram1 += 1000000000u64;
+    histogram1 += 1000_u64;
+    histogram1 += 1000000000_u64;
 
     histogram2 += &histogram1;
-    assert!(histogram2.equivalent(histogram2.max(), 1000000000u64));
+    assert!(histogram2.equivalent(histogram2.max(), 1000000000_u64));
 }
 
 #[test]
 fn autosizing_across_continuous_range() {
     let mut histogram = Histogram::<u64>::new(2).unwrap();
 
-    for i in 0..10000000u64 {
+    for i in 0..10000000_u64 {
         histogram += i;
     }
 }

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -151,16 +151,16 @@ fn get_stdev() {
 
     // direct avg. of raw results
     let expectedRawMean: f64 = ((10000.0 * 1000.0) + (1.0 * 100000000.0)) / 10001.0;
-    let expectedRawStdDev = (((10000.0 * (1000f64 - expectedRawMean).powi(2)) +
-                              (100000000f64 - expectedRawMean).powi(2)) /
+    let expectedRawStdDev = (((10000.0 * (1000_f64 - expectedRawMean).powi(2)) +
+                              (100000000_f64 - expectedRawMean).powi(2)) /
                              10001.0)
         .sqrt();
 
     // avg. 1 msec for half the time, and 50 sec for other half
-    let expectedMean = (1000.0 + 50000000.0) / 2f64;
-    let mut expectedSquareDeviationSum = 10000.0 * (1000f64 - expectedMean).powi(2);
+    let expectedMean = (1000.0 + 50000000.0) / 2_f64;
+    let mut expectedSquareDeviationSum = 10000.0 * (1000_f64 - expectedMean).powi(2);
 
-    let mut value = 10000f64;
+    let mut value = 10000_f64;
     while value <= 100000000.0 {
         expectedSquareDeviationSum += (value - expectedMean).powi(2);
         value += 10000.0;
@@ -193,7 +193,7 @@ fn percentiles() {
 
 #[test]
 fn large_percentile() {
-    let largestValue = 1000000000000u64;
+    let largestValue = 1000000000000_u64;
     let mut h = Histogram::<u64>::new_with_max(largestValue, 5).unwrap();
     h += largestValue;
     assert!(h.value_at_percentile(100.0) > 0);
@@ -204,7 +204,7 @@ fn percentile_atorbelow() {
     let Loaded { hist, raw, .. } = load_histograms();
     assert_near!(99.99, raw.percentile_below(5000), 0.0001);
     assert_near!(50.0, hist.percentile_below(5000), 0.0001);
-    assert_near!(100.0, hist.percentile_below(100000000u64), 0.0001);
+    assert_near!(100.0, hist.percentile_below(100000000_u64), 0.0001);
 }
 
 #[test]


### PR DESCRIPTION
In a few of these literals it took me a double-take to spot the type suffix so I figured I should change all of them rather than have it be inconsistent. If you don't like it, feel free to close; I don't feel strongly about it.