### PR TITLE
Use a struct instead of a tuple for iteration

### DIFF
--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -50,14 +50,43 @@ pub struct HistogramIterator<'a, T: 'a + Counter, P: PickyIterator<T>> {
 /// The value emitted at each step when iterating over a `Histogram`.
 #[derive(Debug, PartialEq)]
 pub struct IterationValue<T: Counter> {
+    value: u64,
+    percentile: f64,
+    count_at_value: T,
+    count_since_last_iteration: u64
+}
+
+impl<T: Counter> IterationValue<T> {
+    /// Create a new IterationValue.
+    pub fn new(value: u64, percentile: f64, count_at_value: T, count_since_last_iteration: u64)
+            -> IterationValue<T> {
+        IterationValue {
+            value: value,
+            percentile: percentile,
+            count_at_value: count_at_value,
+            count_since_last_iteration: count_since_last_iteration
+        }
+    }
+
     /// the lowest value stored in the current histogram bin
-    pub value: u64,
+    pub fn value(&self) -> u64 {
+        self.value
+    }
+
     /// percent of recorded values that are equivalent to or below `value`
-    pub percentile: f64,
+    pub fn percentile(&self) -> f64 {
+        self.percentile
+    }
+
     /// recorded count for values equivalent to `value`
-    pub count_at_value: T,
+    pub fn count_at_value(&self) -> T {
+        self.count_at_value
+    }
+
     /// number of values traversed since the last iteration step
-    pub count_since_last_iteration: u64
+    pub fn count_since_last_iteration(&self) -> u64 {
+        self.count_since_last_iteration
+    }
 }
 
 impl<'a, T: Counter, P: PickyIterator<T>> HistogramIterator<'a, T, P> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,9 @@
 //! use hdrsample::Histogram;
 //! let hist = Histogram::<u64>::new(2).unwrap();
 //! // ...
-//! for (value, percentile, _, count) in hist.iter_recorded() {
-//!     println!("{}'th percentile of data is {} with {} samples", percentile, value, count);
+//! for v in hist.iter_recorded() {
+//!     println!("{}'th percentile of data is {} with {} samples",
+//!         v.percentile, v.value, v.count_at_value);
 //! }
 //! ```
 //!
@@ -146,6 +147,8 @@ use std::ops::IndexMut;
 use std::ops::AddAssign;
 use std::ops::SubAssign;
 use std::borrow::Borrow;
+
+use iterators::HistogramIterator;
 
 /// This auto-implemented marker trait represents the operations a histogram must be able to
 /// perform on the underlying counter type. The `ToPrimitive` trait is needed to perform floating
@@ -336,8 +339,8 @@ impl<T: Counter> Histogram<T> {
     /// larger than `interval`.
     pub fn clone_correct(&self, interval: u64) -> Histogram<T> {
         let mut h = Histogram::new_from(self);
-        for (value, _, count, _) in self.iter_recorded() {
-            h.record_n_correct(value, count, interval).unwrap();
+        for v in self.iter_recorded() {
+            h.record_n_correct(v.value, v.count_at_value, interval).unwrap();
         }
         h
     }
@@ -456,8 +459,8 @@ impl<T: Counter> Histogram<T> {
                                                 -> Result<(), ()> {
         let source = source.borrow();
 
-        for (value, _, count, _) in source.iter_recorded() {
-            try!(self.record_n_correct(value, count, interval));
+        for v in source.iter_recorded() {
+            try!(self.record_n_correct(v.value, v.count_at_value, interval));
         }
         Ok(())
     }
@@ -784,13 +787,11 @@ impl<T: Counter> Histogram<T> {
     /// `halving_period` values have been emitted, the percentile step size is halved, and the
     /// iteration continues.
     ///
-    /// The iterator yields a four-value tuple with the following values (in order): the value at
-    /// the current iterator step, the percentile of samples at or below that value, the number of
-    /// samples recorded at this value, and the number of samples present between the last iterator
-    /// value and the current one.
+    /// The iterator yields an `iterators::IterationValue` struct.
     ///
     /// ```
     /// use hdrsample::Histogram;
+    /// use hdrsample::iterators::IterationValue;
     /// let mut hist = Histogram::<u64>::new_with_max(10000, 4).unwrap();
     /// for i in 0..10000 {
     ///     hist += i;
@@ -800,23 +801,27 @@ impl<T: Counter> Histogram<T> {
     ///
     /// println!("{:?}", hist.iter_percentiles(1).collect::<Vec<_>>());
     ///
-    /// assert_eq!(perc.next(), Some((hist.value_at_percentile(0.01), 0.01, 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(0.01),
+    ///     percentile: 0.01, count_at_value: 1, count_since_last_iteration: 1 }));
     /// // step size = 50
-    /// assert_eq!(perc.next(), Some((hist.value_at_percentile(50.0), 50.0, 1, 5000 - 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(50.0),
+    ///     percentile: 50.0, count_at_value: 1, count_since_last_iteration: 5000 - 1 }));
     /// // step size = 25
-    /// assert_eq!(perc.next(), Some((hist.value_at_percentile(75.0), 75.0, 1, 2500)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(75.0),
+    ///     percentile: 75.0, count_at_value: 1, count_since_last_iteration: 2500 }));
     /// // step size = 12.5
-    /// assert_eq!(perc.next(), Some((hist.value_at_percentile(87.5), 87.5, 1, 1250)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(87.5),
+    ///     percentile: 87.5, count_at_value: 1, count_since_last_iteration: 1250 }));
     /// // step size = 6.25
-    /// assert_eq!(perc.next(), Some((hist.value_at_percentile(93.75), 93.75, 1, 625)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(93.75),
+    ///     percentile: 93.75, count_at_value: 1, count_since_last_iteration: 625 }));
     /// // step size = 3.125
-    /// assert_eq!(perc.next(), Some((hist.value_at_percentile(96.88), 96.88, 1, 313)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(96.88),
+    ///     percentile: 96.88, count_at_value: 1, count_since_last_iteration: 313 }));
     /// // etc...
     /// ```
-    pub fn iter_percentiles<'a>
-        (&'a self,
-         percentileTicksPerHalfDistance: isize)
-         -> iterators::HistogramIterator<'a, T, iterators::percentile::Iter<'a, T>> {
+    pub fn iter_percentiles<'a>(&'a self, percentileTicksPerHalfDistance: isize)
+            -> HistogramIterator<'a, T, iterators::percentile::Iter<'a, T>> {
         iterators::percentile::Iter::new(self, percentileTicksPerHalfDistance)
     }
 
@@ -825,13 +830,11 @@ impl<T: Counter> Histogram<T> {
     /// range of size `step`. The iterator terminates when all recorded histogram values are
     /// exhausted.
     ///
-    /// The iterator yields a four-value tuple with the following values (in order): the value at
-    /// the current iterator step, the percentile of samples at or below that value, the number of
-    /// samples recorded at this value, and the number of samples present between the last iterator
-    /// value and the current one.
+    /// The iterator yields an `iterators::IterationValue` struct.
     ///
     /// ```
     /// use hdrsample::Histogram;
+    /// use hdrsample::iterators::IterationValue;
     /// let mut hist = Histogram::<u64>::new_with_max(1000, 3).unwrap();
     /// hist += 100;
     /// hist += 500;
@@ -839,21 +842,28 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_linear(100);
-    /// assert_eq!(perc.next(), Some((99, hist.percentile_below(99), 0, 0)));
-    /// assert_eq!(perc.next(), Some((199, hist.percentile_below(199), 0, 1)));
-    /// assert_eq!(perc.next(), Some((299, hist.percentile_below(299), 0, 0)));
-    /// assert_eq!(perc.next(), Some((399, hist.percentile_below(399), 0, 0)));
-    /// assert_eq!(perc.next(), Some((499, hist.percentile_below(499), 0, 0)));
-    /// assert_eq!(perc.next(), Some((599, hist.percentile_below(599), 0, 1)));
-    /// assert_eq!(perc.next(), Some((699, hist.percentile_below(699), 0, 0)));
-    /// assert_eq!(perc.next(), Some((799, hist.percentile_below(799), 0, 0)));
-    /// assert_eq!(perc.next(), Some((899, hist.percentile_below(899), 0, 2)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 99,
+    ///     percentile: hist.percentile_below(99), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 199,
+    ///     percentile: hist.percentile_below(199), count_at_value: 0, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 299,
+    ///     percentile: hist.percentile_below(299), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 399,
+    ///     percentile: hist.percentile_below(399), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 499,
+    ///     percentile: hist.percentile_below(499), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 599,
+    ///     percentile: hist.percentile_below(599), count_at_value: 0, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 699,
+    ///     percentile: hist.percentile_below(699), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 799,
+    ///     percentile: hist.percentile_below(799), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 899,
+    ///     percentile: hist.percentile_below(899), count_at_value: 0, count_since_last_iteration: 2 }));
     /// assert_eq!(perc.next(), None);
     /// ```
-    pub fn iter_linear<'a>
-        (&'a self,
-         step: u64)
-         -> iterators::HistogramIterator<'a, T, iterators::linear::Iter<'a, T>> {
+    pub fn iter_linear<'a>(&'a self, step: u64)
+            -> HistogramIterator<'a, T, iterators::linear::Iter<'a, T>> {
         iterators::linear::Iter::new(self, step)
     }
 
@@ -861,13 +871,11 @@ impl<T: Counter> Histogram<T> {
     /// performed in steps that start at `start` and increase exponentially according to `exp`. The
     /// iterator terminates when all recorded histogram values are exhausted.
     ///
-    /// The iterator yields a four-value tuple with the following values (in order): the value at
-    /// the current iterator step, the percentile of samples at or below that value, the number of
-    /// samples recorded at this value, and the number of samples present between the last iterator
-    /// value and the current one.
+    /// The iterator yields an `iterators::IterationValue` struct.
     ///
     /// ```
     /// use hdrsample::Histogram;
+    /// use hdrsample::iterators::IterationValue;
     /// let mut hist = Histogram::<u64>::new_with_max(1000, 3).unwrap();
     /// hist += 100;
     /// hist += 500;
@@ -875,16 +883,18 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_log(1, 10.0);
-    /// assert_eq!(perc.next(), Some((0, hist.percentile_below(0), 0, 0)));
-    /// assert_eq!(perc.next(), Some((9, hist.percentile_below(9), 0, 0)));
-    /// assert_eq!(perc.next(), Some((99, hist.percentile_below(99), 0, 0)));
-    /// assert_eq!(perc.next(), Some((999, hist.percentile_below(999), 0, 4)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 0,
+    ///     percentile: hist.percentile_below(0), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 9,
+    ///     percentile: hist.percentile_below(9), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 99,
+    ///     percentile: hist.percentile_below(99), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 999,
+    ///     percentile: hist.percentile_below(999), count_at_value: 0, count_since_last_iteration: 4 }));
     /// assert_eq!(perc.next(), None);
     /// ```
-    pub fn iter_log<'a>(&'a self,
-                        start: u64,
-                        exp: f64)
-                        -> iterators::HistogramIterator<'a, T, iterators::log::Iter<'a, T>> {
+    pub fn iter_log<'a>(&'a self, start: u64, exp: f64)
+            -> HistogramIterator<'a, T, iterators::log::Iter<'a, T>> {
         iterators::log::Iter::new(self, start, exp)
     }
 
@@ -892,13 +902,11 @@ impl<T: Counter> Histogram<T> {
     /// by the underlying representation. The iteration steps through all non-zero recorded value
     /// counts, and terminates when all recorded histogram values are exhausted.
     ///
-    /// The iterator yields a four-value tuple with the following values (in order): the value at
-    /// the current iterator step, the percentile of samples at or below that value, the number of
-    /// samples recorded at this value, and the number of samples present between the last iterator
-    /// value and the current one.
+    /// The iterator yields an `iterators::IterationValue` struct.
     ///
     /// ```
     /// use hdrsample::Histogram;
+    /// use hdrsample::iterators::IterationValue;
     /// let mut hist = Histogram::<u64>::new_with_max(1000, 3).unwrap();
     /// hist += 100;
     /// hist += 500;
@@ -906,15 +914,18 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_recorded();
-    /// assert_eq!(perc.next(), Some((100, hist.percentile_below(100), 1, 1)));
-    /// assert_eq!(perc.next(), Some((500, hist.percentile_below(500), 1, 1)));
-    /// assert_eq!(perc.next(), Some((800, hist.percentile_below(800), 1, 1)));
-    /// assert_eq!(perc.next(), Some((850, hist.percentile_below(850), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 100,
+    ///     percentile: hist.percentile_below(100), count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 500,
+    ///     percentile: hist.percentile_below(500), count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 800,
+    ///     percentile: hist.percentile_below(800), count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 850,
+    ///     percentile: hist.percentile_below(850), count_at_value: 1, count_since_last_iteration: 1 }));
     /// assert_eq!(perc.next(), None);
     /// ```
-    pub fn iter_recorded<'a>
-        (&'a self)
-         -> iterators::HistogramIterator<'a, T, iterators::recorded::Iter<'a, T>> {
+    pub fn iter_recorded<'a>(&'a self)
+            -> HistogramIterator<'a, T, iterators::recorded::Iter<'a, T>> {
         iterators::recorded::Iter::new(self)
     }
 
@@ -923,32 +934,41 @@ impl<T: Counter> Histogram<T> {
     /// regardless of whether or not there were recorded values for that value level, and
     /// terminates when all recorded histogram values are exhausted.
     ///
-    /// The iterator yields a four-value tuple with the following values (in order): the value at
-    /// the current iterator step, the percentile of samples at or below that value, the number of
-    /// samples recorded at this value, and the number of samples present between the last iterator
-    /// value and the current one.
+    /// The iterator yields an `iterators::IterationValue` struct.
     ///
     /// ```
     /// use hdrsample::Histogram;
+    /// use hdrsample::iterators::IterationValue;
     /// let mut hist = Histogram::<u64>::new_with_max(10, 1).unwrap();
     /// hist += 1;
     /// hist += 5;
     /// hist += 8;
     ///
     /// let mut perc = hist.iter_all();
-    /// assert_eq!(perc.next(), Some((0, 0.0, 0, 0)));
-    /// assert_eq!(perc.next(), Some((1, hist.percentile_below(1), 1, 1)));
-    /// assert_eq!(perc.next(), Some((2, hist.percentile_below(2), 0, 0)));
-    /// assert_eq!(perc.next(), Some((3, hist.percentile_below(3), 0, 0)));
-    /// assert_eq!(perc.next(), Some((4, hist.percentile_below(4), 0, 0)));
-    /// assert_eq!(perc.next(), Some((5, hist.percentile_below(5), 1, 1)));
-    /// assert_eq!(perc.next(), Some((6, hist.percentile_below(6), 0, 0)));
-    /// assert_eq!(perc.next(), Some((7, hist.percentile_below(7), 0, 0)));
-    /// assert_eq!(perc.next(), Some((8, hist.percentile_below(8), 1, 1)));
-    /// assert_eq!(perc.next(), Some((9, hist.percentile_below(9), 0, 0)));
-    /// assert_eq!(perc.next(), Some((10, 100.0, 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 0,
+    ///     percentile: 0.0, count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 1,
+    ///     percentile: hist.percentile_below(1), count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 2,
+    ///     percentile: hist.percentile_below(2), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 3,
+    ///     percentile: hist.percentile_below(3), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 4,
+    ///     percentile: hist.percentile_below(4), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 5,
+    ///     percentile: hist.percentile_below(5), count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 6,
+    ///     percentile: hist.percentile_below(6), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 7,
+    ///     percentile: hist.percentile_below(7), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 8,
+    ///     percentile: hist.percentile_below(8), count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 9,
+    ///     percentile: hist.percentile_below(9), count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue { value: 10,
+    ///     percentile: 100.0, count_at_value: 0, count_since_last_iteration: 0 }));
     /// ```
-    pub fn iter_all<'a>(&'a self) -> iterators::HistogramIterator<'a, T, iterators::all::Iter> {
+    pub fn iter_all<'a>(&'a self) -> HistogramIterator<'a, T, iterators::all::Iter> {
         iterators::all::Iter::new(self)
     }
 
@@ -999,9 +1019,10 @@ impl<T: Counter> Histogram<T> {
             return 0.0;
         }
 
-        self.iter_recorded().fold(0.0_f64, |total, (v, _, c, _)| {
+        self.iter_recorded().fold(0.0_f64, |total, v| {
             total +
-            self.median_equivalent(v) as f64 * c.to_f64().unwrap() / self.totalCount as f64
+                self.median_equivalent(v.value) as f64 * v.count_at_value.to_f64().unwrap()
+                    / self.totalCount as f64
         })
     }
 
@@ -1012,9 +1033,9 @@ impl<T: Counter> Histogram<T> {
         }
 
         let mean = self.mean();
-        let geom_dev_tot = self.iter_recorded().fold(0.0_f64, |gdt, (v, _, _, sc)| {
-            let dev = self.median_equivalent(v) as f64 - mean;
-            gdt + (dev * dev) * sc as f64
+        let geom_dev_tot = self.iter_recorded().fold(0.0_f64, |gdt, v| {
+            let dev = self.median_equivalent(v.value) as f64 - mean;
+            gdt + (dev * dev) * v.count_since_last_iteration as f64
         });
 
         (geom_dev_tot / self.totalCount as f64).sqrt()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,6 @@ use std::ops::AddAssign;
 use std::ops::SubAssign;
 use std::borrow::Borrow;
 
-use iterators::HistogramIterator;
-
 /// This auto-implemented marker trait represents the operations a histogram must be able to
 /// perform on the underlying counter type. The `ToPrimitive` trait is needed to perform floating
 /// point operations on the counts (usually for percentiles). The `FromPrimitive` to convert back
@@ -821,7 +819,7 @@ impl<T: Counter> Histogram<T> {
     /// // etc...
     /// ```
     pub fn iter_percentiles<'a>(&'a self, percentileTicksPerHalfDistance: isize)
-            -> HistogramIterator<'a, T, iterators::percentile::Iter<'a, T>> {
+            -> iterators::HistogramIterator<'a, T, iterators::percentile::Iter<'a, T>> {
         iterators::percentile::Iter::new(self, percentileTicksPerHalfDistance)
     }
 
@@ -863,7 +861,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_linear<'a>(&'a self, step: u64)
-            -> HistogramIterator<'a, T, iterators::linear::Iter<'a, T>> {
+            -> iterators::HistogramIterator<'a, T, iterators::linear::Iter<'a, T>> {
         iterators::linear::Iter::new(self, step)
     }
 
@@ -894,7 +892,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_log<'a>(&'a self, start: u64, exp: f64)
-            -> HistogramIterator<'a, T, iterators::log::Iter<'a, T>> {
+            -> iterators::HistogramIterator<'a, T, iterators::log::Iter<'a, T>> {
         iterators::log::Iter::new(self, start, exp)
     }
 
@@ -925,7 +923,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_recorded<'a>(&'a self)
-            -> HistogramIterator<'a, T, iterators::recorded::Iter<'a, T>> {
+            -> iterators::HistogramIterator<'a, T, iterators::recorded::Iter<'a, T>> {
         iterators::recorded::Iter::new(self)
     }
 
@@ -968,7 +966,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), Some(IterationValue { value: 10,
     ///     percentile: 100.0, count_at_value: 0, count_since_last_iteration: 0 }));
     /// ```
-    pub fn iter_all<'a>(&'a self) -> HistogramIterator<'a, T, iterators::all::Iter> {
+    pub fn iter_all<'a>(&'a self) -> iterators::HistogramIterator<'a, T, iterators::all::Iter> {
         iterators::all::Iter::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! // ...
 //! for v in hist.iter_recorded() {
 //!     println!("{}'th percentile of data is {} with {} samples",
-//!         v.percentile, v.value, v.count_at_value);
+//!         v.percentile(), v.value(), v.count_at_value());
 //! }
 //! ```
 //!
@@ -338,7 +338,7 @@ impl<T: Counter> Histogram<T> {
     pub fn clone_correct(&self, interval: u64) -> Histogram<T> {
         let mut h = Histogram::new_from(self);
         for v in self.iter_recorded() {
-            h.record_n_correct(v.value, v.count_at_value, interval).unwrap();
+            h.record_n_correct(v.value(), v.count_at_value(), interval).unwrap();
         }
         h
     }
@@ -458,7 +458,7 @@ impl<T: Counter> Histogram<T> {
         let source = source.borrow();
 
         for v in source.iter_recorded() {
-            try!(self.record_n_correct(v.value, v.count_at_value, interval));
+            try!(self.record_n_correct(v.value(), v.count_at_value(), interval));
         }
         Ok(())
     }
@@ -799,23 +799,17 @@ impl<T: Counter> Histogram<T> {
     ///
     /// println!("{:?}", hist.iter_percentiles(1).collect::<Vec<_>>());
     ///
-    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(0.01),
-    ///     percentile: 0.01, count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_percentile(0.01), 0.01, 1, 1)));
     /// // step size = 50
-    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(50.0),
-    ///     percentile: 50.0, count_at_value: 1, count_since_last_iteration: 5000 - 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_percentile(50.0), 50.0, 1, 5000 - 1)));
     /// // step size = 25
-    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(75.0),
-    ///     percentile: 75.0, count_at_value: 1, count_since_last_iteration: 2500 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_percentile(75.0), 75.0, 1, 2500)));
     /// // step size = 12.5
-    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(87.5),
-    ///     percentile: 87.5, count_at_value: 1, count_since_last_iteration: 1250 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_percentile(87.5), 87.5, 1, 1250)));
     /// // step size = 6.25
-    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(93.75),
-    ///     percentile: 93.75, count_at_value: 1, count_since_last_iteration: 625 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_percentile(93.75), 93.75, 1, 625)));
     /// // step size = 3.125
-    /// assert_eq!(perc.next(), Some(IterationValue { value: hist.value_at_percentile(96.88),
-    ///     percentile: 96.88, count_at_value: 1, count_since_last_iteration: 313 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_percentile(96.88), 96.88, 1, 313)));
     /// // etc...
     /// ```
     pub fn iter_percentiles<'a>(&'a self, percentileTicksPerHalfDistance: isize)
@@ -840,24 +834,15 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_linear(100);
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 99,
-    ///     percentile: hist.percentile_below(99), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 199,
-    ///     percentile: hist.percentile_below(199), count_at_value: 0, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 299,
-    ///     percentile: hist.percentile_below(299), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 399,
-    ///     percentile: hist.percentile_below(399), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 499,
-    ///     percentile: hist.percentile_below(499), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 599,
-    ///     percentile: hist.percentile_below(599), count_at_value: 0, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 699,
-    ///     percentile: hist.percentile_below(699), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 799,
-    ///     percentile: hist.percentile_below(799), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 899,
-    ///     percentile: hist.percentile_below(899), count_at_value: 0, count_since_last_iteration: 2 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(99, hist.percentile_below(99), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(199, hist.percentile_below(199), 0, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(299, hist.percentile_below(299), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(399, hist.percentile_below(399), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(499, hist.percentile_below(499), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(599, hist.percentile_below(599), 0, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(699, hist.percentile_below(699), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(799, hist.percentile_below(799), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(899, hist.percentile_below(899), 0, 2)));
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_linear<'a>(&'a self, step: u64)
@@ -881,14 +866,10 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_log(1, 10.0);
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 0,
-    ///     percentile: hist.percentile_below(0), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 9,
-    ///     percentile: hist.percentile_below(9), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 99,
-    ///     percentile: hist.percentile_below(99), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 999,
-    ///     percentile: hist.percentile_below(999), count_at_value: 0, count_since_last_iteration: 4 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(0, hist.percentile_below(0), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(9, hist.percentile_below(9), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(99, hist.percentile_below(99), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(999, hist.percentile_below(999), 0, 4)));
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_log<'a>(&'a self, start: u64, exp: f64)
@@ -912,14 +893,10 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_recorded();
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 100,
-    ///     percentile: hist.percentile_below(100), count_at_value: 1, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 500,
-    ///     percentile: hist.percentile_below(500), count_at_value: 1, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 800,
-    ///     percentile: hist.percentile_below(800), count_at_value: 1, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 850,
-    ///     percentile: hist.percentile_below(850), count_at_value: 1, count_since_last_iteration: 1 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(100, hist.percentile_below(100), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(500, hist.percentile_below(500), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(800, hist.percentile_below(800), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(850, hist.percentile_below(850), 1, 1)));
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_recorded<'a>(&'a self)
@@ -943,28 +920,17 @@ impl<T: Counter> Histogram<T> {
     /// hist += 8;
     ///
     /// let mut perc = hist.iter_all();
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 0,
-    ///     percentile: 0.0, count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 1,
-    ///     percentile: hist.percentile_below(1), count_at_value: 1, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 2,
-    ///     percentile: hist.percentile_below(2), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 3,
-    ///     percentile: hist.percentile_below(3), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 4,
-    ///     percentile: hist.percentile_below(4), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 5,
-    ///     percentile: hist.percentile_below(5), count_at_value: 1, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 6,
-    ///     percentile: hist.percentile_below(6), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 7,
-    ///     percentile: hist.percentile_below(7), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 8,
-    ///     percentile: hist.percentile_below(8), count_at_value: 1, count_since_last_iteration: 1 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 9,
-    ///     percentile: hist.percentile_below(9), count_at_value: 0, count_since_last_iteration: 0 }));
-    /// assert_eq!(perc.next(), Some(IterationValue { value: 10,
-    ///     percentile: 100.0, count_at_value: 0, count_since_last_iteration: 0 }));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(0, 0.0, 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(1, hist.percentile_below(1), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(2, hist.percentile_below(2), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(3, hist.percentile_below(3), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(4, hist.percentile_below(4), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(5, hist.percentile_below(5), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(6, hist.percentile_below(6), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(7, hist.percentile_below(7), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(8, hist.percentile_below(8), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(9, hist.percentile_below(9), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(10, 100.0, 0, 0)));
     /// ```
     pub fn iter_all<'a>(&'a self) -> iterators::HistogramIterator<'a, T, iterators::all::Iter> {
         iterators::all::Iter::new(self)
@@ -1019,7 +985,7 @@ impl<T: Counter> Histogram<T> {
 
         self.iter_recorded().fold(0.0_f64, |total, v| {
             total +
-                self.median_equivalent(v.value) as f64 * v.count_at_value.to_f64().unwrap()
+                self.median_equivalent(v.value()) as f64 * v.count_at_value().to_f64().unwrap()
                     / self.totalCount as f64
         })
     }
@@ -1032,8 +998,8 @@ impl<T: Counter> Histogram<T> {
 
         let mean = self.mean();
         let geom_dev_tot = self.iter_recorded().fold(0.0_f64, |gdt, v| {
-            let dev = self.median_equivalent(v.value) as f64 - mean;
-            gdt + (dev * dev) * v.count_since_last_iteration as f64
+            let dev = self.median_equivalent(v.value()) as f64 - mean;
+            gdt + (dev * dev) * v.count_since_last_iteration() as f64
         });
 
         (geom_dev_tot / self.totalCount as f64).sqrt()

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -228,7 +228,7 @@ fn count_at() {
 fn perc_iter() {
     let Loaded { hist, .. } = load_histograms();
     for v in hist.iter_percentiles(5 /* ticks per half */) {
-        assert_eq!(v.value, hist.highest_equivalent(hist.value_at_percentile(v.percentile)));
+        assert_eq!(v.value(), hist.highest_equivalent(hist.value_at_percentile(v.percentile())));
     }
 }
 
@@ -247,11 +247,11 @@ fn linear_iter() {
     for (i, v) in raw.iter_linear(100000).enumerate() {
         match i {
             // Raw Linear 100 msec bucket # 0 added a count of 10000
-            0 => assert_eq!(v.count_since_last_iteration, 10000),
+            0 => assert_eq!(v.count_since_last_iteration(), 10000),
             // Raw Linear 100 msec bucket # 999 added a count of 1
-            999 => assert_eq!(v.count_since_last_iteration, 1),
+            999 => assert_eq!(v.count_since_last_iteration(), 1),
             // Remaining raw Linear 100 msec buckets add a count of 0
-            _ => assert_eq!(v.count_since_last_iteration, 0),
+            _ => assert_eq!(v.count_since_last_iteration(), 0),
         }
         num += 1;
     }
@@ -262,7 +262,7 @@ fn linear_iter() {
     // Iterate data using linear buckets of 10 msec each.
     for (i, v) in hist.iter_linear(10000).enumerate() {
         if i == 0 {
-            assert_eq!(v.count_since_last_iteration, 10000);
+            assert_eq!(v.count_since_last_iteration(), 10000);
         }
 
         // Because value resolution is low enough (3 digits) that multiple linear buckets will end
@@ -270,7 +270,7 @@ fn linear_iter() {
         // 2 or more, and some will have 0 (when the first bucket in the equivalent range was the
         // one that got the total count bump). However, we can still verify the sum of counts added
         // in all the buckets...
-        totalAddedCounts += v.count_since_last_iteration;
+        totalAddedCounts += v.count_since_last_iteration();
         num += 1;
     }
     // There should be 10000 linear buckets of size 10000 usec between 0 and 100 sec.
@@ -282,7 +282,7 @@ fn linear_iter() {
     // Iterate data using linear buckets of 1 msec each.
     for (i, v) in hist.iter_linear(1000).enumerate() {
         if i == 1 {
-            assert_eq!(v.count_since_last_iteration, 10000);
+            assert_eq!(v.count_since_last_iteration(), 10000);
         }
 
         // Because value resolution is low enough (3 digits) that multiple linear buckets will end
@@ -290,7 +290,7 @@ fn linear_iter() {
         // 2 or more, and some will have 0 (when the first bucket in the equivalent range was the
         // one that got the total count bump). However, we can still verify the sum of counts added
         // in all the buckets...
-        totalAddedCounts += v.count_since_last_iteration;
+        totalAddedCounts += v.count_since_last_iteration();
         num += 1
     }
 
@@ -316,11 +316,11 @@ fn iter_log() {
     for (i, v) in raw.iter_log(10000, 2.0).enumerate() {
         match i {
             // Raw logarithmic 10 msec bucket # 0 added a count of 10000
-            0 => assert_eq!(v.count_since_last_iteration, 10000),
+            0 => assert_eq!(v.count_since_last_iteration(), 10000),
             // Raw logarithmic 10 msec bucket # 14 added a count of 1
-            14 => assert_eq!(v.count_since_last_iteration, 1),
+            14 => assert_eq!(v.count_since_last_iteration(), 1),
             // Remaining raw logarithmic 100 msec buckets add a count of 0
-            _ => assert_eq!(v.count_since_last_iteration, 0),
+            _ => assert_eq!(v.count_since_last_iteration(), 0),
         }
         num += 1;
     }
@@ -330,9 +330,9 @@ fn iter_log() {
     let mut totalAddedCounts = 0;
     for (i, v) in hist.iter_log(10000, 2.0).enumerate() {
         if i == 0 {
-            assert_eq!(v.count_since_last_iteration, 10000);
+            assert_eq!(v.count_since_last_iteration(), 10000);
         }
-        totalAddedCounts += v.count_since_last_iteration;
+        totalAddedCounts += v.count_since_last_iteration();
         num += 1;
     }
     // There should be 14 Logarithmic buckets of size 10000 usec between 0 and 100 sec.
@@ -349,9 +349,9 @@ fn iter_recorded() {
     for (i, v) in raw.iter_recorded().enumerate() {
         match i {
             // Raw recorded value bucket # 0 added a count of 10000
-            0 => assert_eq!(v.count_since_last_iteration, 10000),
+            0 => assert_eq!(v.count_since_last_iteration(), 10000),
             // Remaining recorded value buckets add a count of 1
-            _ => assert_eq!(v.count_since_last_iteration, 1),
+            _ => assert_eq!(v.count_since_last_iteration(), 1),
         }
         num += 1;
     }
@@ -361,16 +361,16 @@ fn iter_recorded() {
     let mut totalAddedCounts = 0;
     for (i, v) in hist.iter_recorded().enumerate() {
         if i == 0 {
-            assert_eq!(v.count_since_last_iteration, 10000);
+            assert_eq!(v.count_since_last_iteration(), 10000);
         }
 
         // The count in a recorded iterator value should never be zero
-        assert!(v.count_at_value != 0);
+        assert!(v.count_at_value() != 0);
         // The count in a recorded iterator value should exactly match the amount added since the
         // last iteration
-        assert_eq!(v.count_at_value, v.count_since_last_iteration);
+        assert_eq!(v.count_at_value(), v.count_since_last_iteration());
 
-        totalAddedCounts += v.count_since_last_iteration;
+        totalAddedCounts += v.count_since_last_iteration();
         num += 1;
     }
     assert_eq!(totalAddedCounts, 20000);
@@ -384,11 +384,11 @@ fn iter_all() {
     let mut num = 0;
     for (i, v) in raw.iter_all().enumerate() {
         if i == 1000 {
-            assert_eq!(v.count_since_last_iteration, 10000);
-        } else if hist.equivalent(v.value, 100000000) {
-            assert_eq!(v.count_since_last_iteration, 1);
+            assert_eq!(v.count_since_last_iteration(), 10000);
+        } else if hist.equivalent(v.value(), 100000000) {
+            assert_eq!(v.count_since_last_iteration(), 1);
         } else {
-            assert_eq!(v.count_since_last_iteration, 0);
+            assert_eq!(v.count_since_last_iteration(), 0);
         }
 
         // TODO: also test total count and total value once the iterator exposes this
@@ -402,14 +402,14 @@ fn iter_all() {
     for (i, v) in hist.iter_all().enumerate() {
         // v1 = v;
         if i == 1000 {
-            assert_eq!(v.count_since_last_iteration, 10000);
+            assert_eq!(v.count_since_last_iteration(), 10000);
         }
 
         // The count in iter_all buckets should exactly match the amount added since the last iteration
-        assert_eq!(v.count_at_value, v.count_since_last_iteration);
-        totalAddedCounts += v.count_since_last_iteration;
+        assert_eq!(v.count_at_value(), v.count_since_last_iteration());
+        totalAddedCounts += v.count_since_last_iteration();
         // valueFromIndex(index) should be equal to getValueIteratedTo()
-        assert!(hist.equivalent(hist.value_for(i), v.value));
+        assert!(hist.equivalent(hist.value_for(i), v.value()));
         num += 1;
     }
     assert_eq!(num, hist.len());
@@ -438,9 +438,9 @@ fn value_duplication() {
     let mut ranges = Vec::with_capacity(histogram1.len());
     let mut counts = Vec::with_capacity(histogram1.len());
     for v in histogram1.iter_all() {
-        if v.count_since_last_iteration > 0 {
-            ranges.push(v.value);
-            counts.push(v.count_since_last_iteration);
+        if v.count_since_last_iteration() > 0 {
+            ranges.push(v.value());
+            counts.push(v.count_since_last_iteration());
         }
         num += 1;
     }

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -25,7 +25,7 @@ macro_rules! assert_near {
 fn verify_max<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) -> bool {
     let hist = hist.borrow();
     if let Some(mx) = hist.iter_recorded()
-        .map(|(v, _, _, _)| v)
+        .map(|v| v.value)
         .map(|v| hist.highest_equivalent(v))
         .last() {
         hist.max() == mx

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -25,7 +25,7 @@ macro_rules! assert_near {
 fn verify_max<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) -> bool {
     let hist = hist.borrow();
     if let Some(mx) = hist.iter_recorded()
-        .map(|v| v.value)
+        .map(|v| v.value())
         .map(|v| hist.highest_equivalent(v))
         .last() {
         hist.max() == mx


### PR DESCRIPTION
This seems less error prone to work with, allows us to centralize the docs on what each component means, and will also allow us to unobtrusively add more fields. Performance shouldn't be affected since tuples are just anonymous structs, AFAIK.