### PR TITLE
Re-applying the `use` for HistogramIterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,8 @@ use std::ops::AddAssign;
 use std::ops::SubAssign;
 use std::borrow::Borrow;
 
+use iterators::HistogramIterator;
+
 /// This auto-implemented marker trait represents the operations a histogram must be able to
 /// perform on the underlying counter type. The `ToPrimitive` trait is needed to perform floating
 /// point operations on the counts (usually for percentiles). The `FromPrimitive` to convert back
@@ -813,7 +815,7 @@ impl<T: Counter> Histogram<T> {
     /// // etc...
     /// ```
     pub fn iter_percentiles<'a>(&'a self, percentileTicksPerHalfDistance: isize)
-            -> iterators::HistogramIterator<'a, T, iterators::percentile::Iter<'a, T>> {
+            -> HistogramIterator<'a, T, iterators::percentile::Iter<'a, T>> {
         iterators::percentile::Iter::new(self, percentileTicksPerHalfDistance)
     }
 
@@ -846,7 +848,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_linear<'a>(&'a self, step: u64)
-            -> iterators::HistogramIterator<'a, T, iterators::linear::Iter<'a, T>> {
+            -> HistogramIterator<'a, T, iterators::linear::Iter<'a, T>> {
         iterators::linear::Iter::new(self, step)
     }
 
@@ -873,7 +875,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_log<'a>(&'a self, start: u64, exp: f64)
-            -> iterators::HistogramIterator<'a, T, iterators::log::Iter<'a, T>> {
+            -> HistogramIterator<'a, T, iterators::log::Iter<'a, T>> {
         iterators::log::Iter::new(self, start, exp)
     }
 
@@ -900,7 +902,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_recorded<'a>(&'a self)
-            -> iterators::HistogramIterator<'a, T, iterators::recorded::Iter<'a, T>> {
+            -> HistogramIterator<'a, T, iterators::recorded::Iter<'a, T>> {
         iterators::recorded::Iter::new(self)
     }
 
@@ -932,7 +934,7 @@ impl<T: Counter> Histogram<T> {
     /// assert_eq!(perc.next(), Some(IterationValue::new(9, hist.percentile_below(9), 0, 0)));
     /// assert_eq!(perc.next(), Some(IterationValue::new(10, 100.0, 0, 0)));
     /// ```
-    pub fn iter_all<'a>(&'a self) -> iterators::HistogramIterator<'a, T, iterators::all::Iter> {
+    pub fn iter_all<'a>(&'a self) -> HistogramIterator<'a, T, iterators::all::Iter> {
         iterators::all::Iter::new(self)
     }
 


### PR DESCRIPTION
The leftover bit pulled from the iterator struct PR.