### PR TITLE
Use snake case for var names. Enable a few rustc deny options.

### DIFF
--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -22,7 +22,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
                                Iter {
                                    hist: hist,
                                    value_units_per_bucket: value_units_per_bucket,
-                                   // won't underflow because valueUnitsPerBucket > 0
+                                   // won't underflow because value_units_per_bucket > 0
                                    current_step_highest_value_reporting_level: value_units_per_bucket - 1,
                                    current_step_lowest_value_reporting_level:
                                        hist.lowest_equivalent(value_units_per_bucket - 1),

--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -7,25 +7,25 @@ pub struct Iter<'a, T: 'a + Counter> {
     hist: &'a Histogram<T>,
 
     // > 0
-    valueUnitsPerBucket: u64,
-    currentStepHighestValueReportingLevel: u64,
-    currentStepLowestValueReportingLevel: u64,
+    value_units_per_bucket: u64,
+    current_step_highest_value_reporting_level: u64,
+    current_step_lowest_value_reporting_level: u64,
 }
 
 impl<'a, T: 'a + Counter> Iter<'a, T> {
     /// Construct a new linear iterator. See `Histogram::iter_linear` for details.
     pub fn new(hist: &'a Histogram<T>,
-               valueUnitsPerBucket: u64)
+               value_units_per_bucket: u64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
-        assert!(valueUnitsPerBucket > 0, "valueUnitsPerBucket must be > 0");
+        assert!(value_units_per_bucket > 0, "value_units_per_bucket must be > 0");
         HistogramIterator::new(hist,
                                Iter {
                                    hist: hist,
-                                   valueUnitsPerBucket: valueUnitsPerBucket,
+                                   value_units_per_bucket: value_units_per_bucket,
                                    // won't underflow because valueUnitsPerBucket > 0
-                                   currentStepHighestValueReportingLevel: valueUnitsPerBucket - 1,
-                                   currentStepLowestValueReportingLevel:
-                                       hist.lowest_equivalent(valueUnitsPerBucket - 1),
+                                   current_step_highest_value_reporting_level: value_units_per_bucket - 1,
+                                   current_step_lowest_value_reporting_level:
+                                       hist.lowest_equivalent(value_units_per_bucket - 1),
                                })
     }
 }
@@ -33,10 +33,10 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
     fn pick(&mut self, index: usize, _: u64) -> bool {
         let val = self.hist.value_for(index);
-        if val >= self.currentStepLowestValueReportingLevel || index == self.hist.last() {
-            self.currentStepHighestValueReportingLevel += self.valueUnitsPerBucket;
-            self.currentStepLowestValueReportingLevel = self.hist
-                .lowest_equivalent(self.currentStepHighestValueReportingLevel);
+        if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last() {
+            self.current_step_highest_value_reporting_level += self.value_units_per_bucket;
+            self.current_step_lowest_value_reporting_level = self.hist
+                .lowest_equivalent(self.current_step_highest_value_reporting_level);
             true
         } else {
             false
@@ -48,6 +48,6 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // if we reached this point), then we are not yet done iterating (we want to iterate
         // until we are no longer on a value that has a count, rather than util we first reach
         // the last value that has a count. The difference is subtle but important)...
-        self.currentStepHighestValueReportingLevel + 1 < self.hist.value_for(index + 1)
+        self.current_step_highest_value_reporting_level + 1 < self.hist.value_for(index + 1)
     }
 }

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -7,31 +7,31 @@ pub struct Iter<'a, T: 'a + Counter> {
     hist: &'a Histogram<T>,
 
     // > 1.0
-    nextValueReportingLevel: f64,
+    next_value_reporting_level: f64,
     // > 1.0
-    logBase: f64,
+    log_base: f64,
 
-    currentStepLowestValueReportingLevel: u64,
-    currentStepHighestValueReportingLevel: u64,
+    current_step_lowest_value_reporting_level: u64,
+    current_step_highest_value_reporting_level: u64,
 }
 
 impl<'a, T: 'a + Counter> Iter<'a, T> {
     /// Construct a new logarithmic iterator. See `Histogram::iter_log` for details.
     pub fn new(hist: &'a Histogram<T>,
-               valueUnitsInFirstBucket: u64,
-               logBase: f64)
+               value_units_in_first_bucket: u64,
+               log_base: f64)
                -> HistogramIterator<'a, T, Iter<'a, T>> {
-        assert!(valueUnitsInFirstBucket > 0, "valueUnitsPerBucket must be > 0");
-        assert!(logBase > 1.0, "logBase must be > 1.0");
+        assert!(value_units_in_first_bucket > 0, "value_units_per_bucket must be > 0");
+        assert!(log_base > 1.0, "log_base must be > 1.0");
         HistogramIterator::new(hist,
                                Iter {
                                    hist: hist,
-                                   logBase: logBase,
-                                   nextValueReportingLevel: valueUnitsInFirstBucket as f64,
-                                   currentStepHighestValueReportingLevel: valueUnitsInFirstBucket -
+                                   log_base: log_base,
+                                   next_value_reporting_level: value_units_in_first_bucket as f64,
+                                   current_step_highest_value_reporting_level: value_units_in_first_bucket -
                                                                           1,
-                                   currentStepLowestValueReportingLevel:
-                                       hist.lowest_equivalent(valueUnitsInFirstBucket - 1),
+                                   current_step_lowest_value_reporting_level:
+                                       hist.lowest_equivalent(value_units_in_first_bucket - 1),
                                })
     }
 }
@@ -39,13 +39,13 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
     fn pick(&mut self, index: usize, _: u64) -> bool {
         let val = self.hist.value_for(index);
-        if val >= self.currentStepLowestValueReportingLevel || index == self.hist.last() {
+        if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last() {
             // implies logBase must be > 1.0
-            self.nextValueReportingLevel *= self.logBase;
+            self.next_value_reporting_level *= self.log_base;
             // won't underflow since nextValueReportingLevel starts > 0 and only grows
-            self.currentStepHighestValueReportingLevel = self.nextValueReportingLevel as u64 - 1;
-            self.currentStepLowestValueReportingLevel = self.hist
-                .lowest_equivalent(self.currentStepHighestValueReportingLevel);
+            self.current_step_highest_value_reporting_level = self.next_value_reporting_level as u64 - 1;
+            self.current_step_lowest_value_reporting_level = self.hist
+                .lowest_equivalent(self.current_step_highest_value_reporting_level);
             true
         } else {
             false
@@ -57,7 +57,7 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // reached this point), then we are not yet done iterating (we want to iterate until we are
         // no longer on a value that has a count, rather than util we first reach the last value
         // that has a count. The difference is subtle but important)...
-        self.hist.lowest_equivalent(self.nextValueReportingLevel as u64) <
+        self.hist.lowest_equivalent(self.next_value_reporting_level as u64) <
             self.hist.value_for(next_index)
     }
 }

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -40,9 +40,9 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
     fn pick(&mut self, index: usize, _: u64) -> bool {
         let val = self.hist.value_for(index);
         if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last() {
-            // implies logBase must be > 1.0
+            // implies log_base must be > 1.0
             self.next_value_reporting_level *= self.log_base;
-            // won't underflow since nextValueReportingLevel starts > 0 and only grows
+            // won't underflow since next_value_reporting_level starts > 0 and only grows
             self.current_step_highest_value_reporting_level = self.next_value_reporting_level as u64 - 1;
             self.current_step_lowest_value_reporting_level = self.hist
                 .lowest_equivalent(self.current_step_highest_value_reporting_level);

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -170,7 +170,7 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
             if self.picker.pick(self.current_index, self.total_count_to_index) {
                 let val = self.current();
 
-                // note that we *don't* increment self.currentIndex here. the picker will be
+                // note that we *don't* increment self.current_index here. the picker will be
                 // exposed to the same value again after yielding. not sure why this is the
                 // behavior we want, but it's what the original Java implementation dictates.
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -39,9 +39,9 @@ pub trait PickyIterator<T: Counter> {
 /// indices they have already visited.
 pub struct HistogramIterator<'a, T: 'a + Counter, P: PickyIterator<T>> {
     hist: &'a Histogram<T>,
-    totalCountToIndex: u64,
-    prevTotalCount: u64,
-    currentIndex: usize,
+    total_count_to_index: u64,
+    prev_total_count: u64,
+    current_index: usize,
     fresh: bool,
     ended: bool,
     picker: P,
@@ -93,9 +93,9 @@ impl<'a, T: Counter, P: PickyIterator<T>> HistogramIterator<'a, T, P> {
     fn new(h: &'a Histogram<T>, picker: P) -> HistogramIterator<'a, T, P> {
         HistogramIterator {
             hist: h,
-            totalCountToIndex: 0,
-            prevTotalCount: 0,
-            currentIndex: 0,
+            total_count_to_index: 0,
+            prev_total_count: 0,
+            current_index: 0,
             picker: picker,
             fresh: true,
             ended: false,
@@ -105,10 +105,10 @@ impl<'a, T: Counter, P: PickyIterator<T>> HistogramIterator<'a, T, P> {
     // (value, percentile, count-for-value, count-for-step)
     fn current(&self) -> IterationValue<T> {
         IterationValue {
-            value: self.hist.highest_equivalent(self.hist.value_for(self.currentIndex)),
-            percentile: 100.0 * self.totalCountToIndex as f64 / self.hist.count() as f64,
-            count_at_value: self.hist[self.currentIndex],
-            count_since_last_iteration: self.totalCountToIndex - self.prevTotalCount
+            value: self.hist.highest_equivalent(self.hist.value_for(self.current_index)),
+            percentile: 100.0 * self.total_count_to_index as f64 / self.hist.count() as f64,
+            count_at_value: self.hist[self.current_index],
+            count_since_last_iteration: self.total_count_to_index - self.prev_total_count
         }
     }
 }
@@ -131,35 +131,35 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
         // unless we have ended.
         while !self.ended {
             // have we reached the end?
-            if self.currentIndex == self.hist.len() {
+            if self.current_index == self.hist.len() {
                 self.ended = true;
                 return None;
             }
 
             // have we yielded all non-zeros in the histogram?
             let total = self.hist.count();
-            if self.prevTotalCount == total {
+            if self.prev_total_count == total {
                 // is the picker done?
-                if !self.picker.more(self.currentIndex) {
+                if !self.picker.more(self.current_index) {
                     self.ended = true;
                     return None;
                 }
 
                 // nope -- alright, let's keep iterating
             } else {
-                assert!(self.currentIndex < self.hist.len());
-                assert!(self.prevTotalCount < total);
+                assert!(self.current_index < self.hist.len());
+                assert!(self.prev_total_count < total);
 
                 if self.fresh {
-                    let count = self.hist[self.currentIndex];
+                    let count = self.hist[self.current_index];
 
                     // if we've seen all counts, no other counts should be non-zero
-                    if self.totalCountToIndex == total {
+                    if self.total_count_to_index == total {
                         assert!(count == T::zero());
                     }
 
                     // maintain total count so we can yield percentiles
-                    self.totalCountToIndex = self.totalCountToIndex + count.to_u64().unwrap();
+                    self.total_count_to_index = self.total_count_to_index + count.to_u64().unwrap();
 
                     // make sure we don't add this index again
                     self.fresh = false;
@@ -167,19 +167,19 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
             }
 
             // figure out if picker thinks we should yield this value
-            if self.picker.pick(self.currentIndex, self.totalCountToIndex) {
+            if self.picker.pick(self.current_index, self.total_count_to_index) {
                 let val = self.current();
 
                 // note that we *don't* increment self.currentIndex here. the picker will be
                 // exposed to the same value again after yielding. not sure why this is the
                 // behavior we want, but it's what the original Java implementation dictates.
 
-                self.prevTotalCount = self.totalCountToIndex;
+                self.prev_total_count = self.total_count_to_index;
                 return Some(val);
             }
 
             // check the next entry
-            self.currentIndex += 1;
+            self.current_index += 1;
             self.fresh = true;
         }
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1275,7 +1275,7 @@ impl<T: Counter> Histogram<T> {
         self.counts.resize(len, T::zero());
     }
 
-    /// Set internally tracked max value to new value if new value is greater than current one.
+    /// Set internally tracked max_value to new value if new value is greater than current one.
     fn update_max(&mut self, value: u64) {
         let internal_value = value | self.unit_magnitude_mask; // Max unit-equivalent value
         if internal_value > self.max_value {
@@ -1283,7 +1283,7 @@ impl<T: Counter> Histogram<T> {
         }
     }
 
-    /// Set internally tracked min non zero value to new value if new value is smaller than current
+    /// Set internally tracked min_non_zero_value to new value if new value is smaller than current
     /// one.
     fn update_min(&mut self, value: u64) {
         if value <= self.unit_magnitude_mask {

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -136,13 +136,13 @@ fn get_mean() {
     let Loaded { hist, raw, .. } = load_histograms();
 
     // direct avg. of raw results
-    let expectedRawMean = ((10000.0 * 1000.0) + (1.0 * 100000000.0)) / 10001.0;
+    let expected_raw_mean = ((10000.0 * 1000.0) + (1.0 * 100000000.0)) / 10001.0;
     // avg. 1 msec for half the time, and 50 sec for other half
-    let expectedMean = (1000.0 + 50000000.0) / 2.0;
+    let expected_mean = (1000.0 + 50000000.0) / 2.0;
 
     // We expect to see the mean to be accurate to ~3 decimal points (~0.1%):
-    assert_near!(raw.mean(), expectedRawMean, 0.001);
-    assert_near!(hist.mean(), expectedMean, 0.001);
+    assert_near!(raw.mean(), expected_raw_mean, 0.001);
+    assert_near!(hist.mean(), expected_mean, 0.001);
 }
 
 #[test]
@@ -150,26 +150,26 @@ fn get_stdev() {
     let Loaded { hist, raw, .. } = load_histograms();
 
     // direct avg. of raw results
-    let expectedRawMean: f64 = ((10000.0 * 1000.0) + (1.0 * 100000000.0)) / 10001.0;
-    let expectedRawStdDev = (((10000.0 * (1000_f64 - expectedRawMean).powi(2)) +
-                              (100000000_f64 - expectedRawMean).powi(2)) /
+    let expected_raw_mean: f64 = ((10000.0 * 1000.0) + (1.0 * 100000000.0)) / 10001.0;
+    let expected_raw_std_dev = (((10000.0 * (1000_f64 - expected_raw_mean).powi(2)) +
+                              (100000000_f64 - expected_raw_mean).powi(2)) /
                              10001.0)
         .sqrt();
 
     // avg. 1 msec for half the time, and 50 sec for other half
-    let expectedMean = (1000.0 + 50000000.0) / 2_f64;
-    let mut expectedSquareDeviationSum = 10000.0 * (1000_f64 - expectedMean).powi(2);
+    let expected_mean = (1000.0 + 50000000.0) / 2_f64;
+    let mut expected_square_deviation_sum = 10000.0 * (1000_f64 - expected_mean).powi(2);
 
     let mut value = 10000_f64;
     while value <= 100000000.0 {
-        expectedSquareDeviationSum += (value - expectedMean).powi(2);
+        expected_square_deviation_sum += (value - expected_mean).powi(2);
         value += 10000.0;
     }
-    let expectedStdDev = (expectedSquareDeviationSum / 20000.0).sqrt();
+    let expected_std_dev = (expected_square_deviation_sum / 20000.0).sqrt();
 
     // We expect to see the standard deviations to be accurate to ~3 decimal points (~0.1%):
-    assert_near!(raw.stdev(), expectedRawStdDev, 0.001);
-    assert_near!(hist.stdev(), expectedStdDev, 0.001);
+    assert_near!(raw.stdev(), expected_raw_std_dev, 0.001);
+    assert_near!(hist.stdev(), expected_std_dev, 0.001);
 }
 
 #[test]
@@ -193,9 +193,9 @@ fn percentiles() {
 
 #[test]
 fn large_percentile() {
-    let largestValue = 1000000000000_u64;
-    let mut h = Histogram::<u64>::new_with_max(largestValue, 5).unwrap();
-    h += largestValue;
+    let largest_value = 1000000000000_u64;
+    let mut h = Histogram::<u64>::new_with_max(largest_value, 5).unwrap();
+    h += largest_value;
     assert!(h.value_at_percentile(100.0) > 0);
 }
 
@@ -258,7 +258,7 @@ fn linear_iter() {
     assert_eq!(num, 1000);
 
     num = 0;
-    let mut totalAddedCounts = 0;
+    let mut total_added_counts = 0;
     // Iterate data using linear buckets of 10 msec each.
     for (i, v) in hist.iter_linear(10000).enumerate() {
         if i == 0 {
@@ -270,15 +270,15 @@ fn linear_iter() {
         // 2 or more, and some will have 0 (when the first bucket in the equivalent range was the
         // one that got the total count bump). However, we can still verify the sum of counts added
         // in all the buckets...
-        totalAddedCounts += v.count_since_last_iteration();
+        total_added_counts += v.count_since_last_iteration();
         num += 1;
     }
     // There should be 10000 linear buckets of size 10000 usec between 0 and 100 sec.
     assert_eq!(num, 10000);
-    assert_eq!(totalAddedCounts, 20000);
+    assert_eq!(total_added_counts, 20000);
 
     num = 0;
-    totalAddedCounts = 0;
+    total_added_counts = 0;
     // Iterate data using linear buckets of 1 msec each.
     for (i, v) in hist.iter_linear(1000).enumerate() {
         if i == 1 {
@@ -290,7 +290,7 @@ fn linear_iter() {
         // 2 or more, and some will have 0 (when the first bucket in the equivalent range was the
         // one that got the total count bump). However, we can still verify the sum of counts added
         // in all the buckets...
-        totalAddedCounts += v.count_since_last_iteration();
+        total_added_counts += v.count_since_last_iteration();
         num += 1
     }
 
@@ -304,7 +304,7 @@ fn linear_iter() {
     // 100000 or 100007 steps. The proper thing to do is to run to the end of the sub-bucket
     // quanta...
     assert_eq!(num, 100007);
-    assert_eq!(totalAddedCounts, 20000);
+    assert_eq!(total_added_counts, 20000);
 }
 
 #[test]
@@ -327,17 +327,17 @@ fn iter_log() {
     assert_eq!(num - 1, 14);
 
     num = 0;
-    let mut totalAddedCounts = 0;
+    let mut total_added_counts = 0;
     for (i, v) in hist.iter_log(10000, 2.0).enumerate() {
         if i == 0 {
             assert_eq!(v.count_since_last_iteration(), 10000);
         }
-        totalAddedCounts += v.count_since_last_iteration();
+        total_added_counts += v.count_since_last_iteration();
         num += 1;
     }
     // There should be 14 Logarithmic buckets of size 10000 usec between 0 and 100 sec.
     assert_eq!(num - 1, 14);
-    assert_eq!(totalAddedCounts, 20000);
+    assert_eq!(total_added_counts, 20000);
 }
 
 #[test]
@@ -358,7 +358,7 @@ fn iter_recorded() {
     assert_eq!(num, 2);
 
     num = 0;
-    let mut totalAddedCounts = 0;
+    let mut total_added_counts = 0;
     for (i, v) in hist.iter_recorded().enumerate() {
         if i == 0 {
             assert_eq!(v.count_since_last_iteration(), 10000);
@@ -370,10 +370,10 @@ fn iter_recorded() {
         // last iteration
         assert_eq!(v.count_at_value(), v.count_since_last_iteration());
 
-        totalAddedCounts += v.count_since_last_iteration();
+        total_added_counts += v.count_since_last_iteration();
         num += 1;
     }
-    assert_eq!(totalAddedCounts, 20000);
+    assert_eq!(total_added_counts, 20000);
 }
 
 #[test]
@@ -397,7 +397,7 @@ fn iter_all() {
     assert_eq!(num, hist.len());
 
     num = 0;
-    let mut totalAddedCounts = 0;
+    let mut total_added_counts = 0;
     // HistogramIterationValue v1 = null;
     for (i, v) in hist.iter_all().enumerate() {
         // v1 = v;
@@ -407,13 +407,13 @@ fn iter_all() {
 
         // The count in iter_all buckets should exactly match the amount added since the last iteration
         assert_eq!(v.count_at_value(), v.count_since_last_iteration());
-        totalAddedCounts += v.count_since_last_iteration();
+        total_added_counts += v.count_since_last_iteration();
         // valueFromIndex(index) should be equal to getValueIteratedTo()
         assert!(hist.equivalent(hist.value_for(i), v.value()));
         num += 1;
     }
     assert_eq!(num, hist.len());
-    assert_eq!(totalAddedCounts, 20000);
+    assert_eq!(total_added_counts, 20000);
 }
 
 #[test]

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -238,7 +238,7 @@ fn linear_iter() {
 
     // Note that using linear buckets should work "as expected" as long as the number of linear
     // buckets is lower than the resolution level determined by
-    // largestValueWithSingleUnitResolution (2000 in this case). Above that count, some of the
+    // largest_value_with_single_unit_resolution (2000 in this case). Above that count, some of the
     // linear buckets can end up rounded up in size (to the nearest local resolution unit level),
     // which can result in a smaller number of buckets that expected covering the range.
 
@@ -408,7 +408,7 @@ fn iter_all() {
         // The count in iter_all buckets should exactly match the amount added since the last iteration
         assert_eq!(v.count_at_value(), v.count_since_last_iteration());
         total_added_counts += v.count_since_last_iteration();
-        // valueFromIndex(index) should be equal to getValueIteratedTo()
+        // value_from_index(index) should be equal to get_value_iterated_to()
         assert!(hist.equivalent(hist.value_for(i), v.value()));
         num += 1;
     }


### PR DESCRIPTION
I'll have some time to work on porting tests again soon so I figured I'd do this now when it's not likely to conflict. Mmm regexes.