### PR TITLE
Reduce memory footprint per histogram.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ benchmark = [] # for crates.io publication
 num = "0.1"
 #criterion = { git = "https://github.com/japaric/criterion.rs.git", optional = true }
 
+[dev-dependencies]
+rand = "0.3.15"
+
 [lib]
 path = "src/lib.rs"
 

--- a/benchmarks/busy.rs
+++ b/benchmarks/busy.rs
@@ -2,7 +2,7 @@ extern crate hdrsample;
 use hdrsample::Histogram;
 
 const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000; // e.g. for 1 hr in usec units
-const SIGFIG: u32 = 3;
+const SIGFIG: u8 = 3;
 const TEST_VALUE_LEVEL: u64 = 12340;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1241,8 +1241,10 @@ impl<T: Counter> Histogram<T> {
 
     #[inline]
     fn value_from_loc(&self, bucket_index: u8, sub_bucket_index: u32) -> u64 {
-        // sum won't overflow; bucket_index and unit_magnitude are both <= 64.
-        // However, the resulting shift may overflow if unit magnitude is large, for instance.
+        // Sum won't overflow; bucket_index and unit_magnitude are both <= 64.
+        // However, the resulting shift may overflow given bogus input, e.g. if unit magnitude is
+        // large and the input sub_bucket_index is for an entry in the counts index that shouldn't
+        // be used (because this calculation will overflow).
         (sub_bucket_index as u64) << (bucket_index + self.unit_magnitude)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1241,7 +1241,8 @@ impl<T: Counter> Histogram<T> {
 
     #[inline]
     fn value_from_loc(&self, bucket_index: u8, sub_bucket_index: u32) -> u64 {
-        // sum won't overflow; bucket_index and unit_magnitude are both <= 64
+        // sum won't overflow; bucket_index and unit_magnitude are both <= 64.
+        // However, the resulting shift may overflow if unit magnitude is large, for instance.
         (sub_bucket_index as u64) << (bucket_index + self.unit_magnitude)
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,7 +35,7 @@ fn init_fields_max_value_max_precision_largest_possible_array() {
     assert_eq!(1 << 17, h.sub_bucket_half_count);
     // 2^46 * 2^18 = 2^64, so 47 buckets.
     assert_eq!(47, h.bucket_count);
-    assert_eq!(46 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len());
+    assert_eq!(46 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len() as u32);
     assert_eq!(17, h.sub_bucket_half_count_magnitude);
     assert_eq!((1 << 18) - 1, h.sub_bucket_mask);
 
@@ -59,7 +59,7 @@ fn init_fields_max_value_medium_precision() {
     assert_eq!(1 << 10, h.sub_bucket_half_count);
     // 2^53 * 2048 == 2^64, so that's 54 buckets.
     assert_eq!(54, h.bucket_count);
-    assert_eq!(53 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len());
+    assert_eq!(53 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len() as u32);
     assert_eq!(10, h.sub_bucket_half_count_magnitude);
     assert_eq!((1 << 11) - 1, h.sub_bucket_mask);
 
@@ -82,7 +82,7 @@ fn init_fields_1_bucket_medium_precision() {
     assert_eq!(1 << 10, h.sub_bucket_half_count);
     // 2^0 * 2048 == 2^11, so that's 1 bucket.
     assert_eq!(1, h.bucket_count);
-    assert_eq!(h.sub_bucket_count, h.counts.len());
+    assert_eq!(h.sub_bucket_count, h.counts.len() as u32);
     assert_eq!(10, h.sub_bucket_half_count_magnitude);
     assert_eq!((1 << 11) - 1, h.sub_bucket_mask);
 
@@ -106,7 +106,7 @@ fn init_fields_max_value_0_precision_most_buckets() {
     // 2^63 * 2 = 2^64, so 64 buckets.
     assert_eq!(64, h.bucket_count);
     // 63 half buckets, one full bucket
-    assert_eq!(63 + 2, h.counts.len());
+    assert_eq!(63 + 2, h.counts.len() as u32);
     assert_eq!(0, h.sub_bucket_half_count_magnitude);
     assert_eq!(1, h.sub_bucket_mask);
 
@@ -131,7 +131,7 @@ fn init_fields_max_value_0_precision_increased_min_value() {
     // 2^54 * 2^10 = 2^64, so 55 buckets.
     assert_eq!(55, h.bucket_count);
     // 54 half buckets, one full bucket
-    assert_eq!(54 + 2, h.counts.len());
+    assert_eq!(54 + 2, h.counts.len() as u32);
     assert_eq!(0, h.sub_bucket_half_count_magnitude);
     assert_eq!(1 << 9, h.sub_bucket_mask);
 
@@ -157,7 +157,7 @@ fn init_fields_max_value_max_precision_increased_min_value() {
     // 2^37 * 2^27 = 2^64, so 38 buckets.
     assert_eq!(38, h.bucket_count);
     // 37 half buckets, one full bucket
-    assert_eq!(37 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len());
+    assert_eq!(37 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len() as u32);
     assert_eq!(17, h.sub_bucket_half_count_magnitude);
     assert_eq!(((1 << 18) - 1) << 9, h.sub_bucket_mask);
 
@@ -184,7 +184,7 @@ fn init_fields_10m_max_1k_min_middle_precision() {
     // 2^4 * 2^20 = 2^24, so 5 buckets.
     assert_eq!(5, h.bucket_count);
     // 4 half buckets, one full bucket
-    assert_eq!(4 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len());
+    assert_eq!(4 * h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len() as u32);
     assert_eq!(10, h.sub_bucket_half_count_magnitude);
     assert_eq!(((1 << 11) - 1) << 9, h.sub_bucket_mask);
 
@@ -210,7 +210,7 @@ fn init_fields_max_value_max_unit_magnitude_0_precision() {
     // 2^1 * 2^63 = 2^64, so 2 buckets.
     assert_eq!(2, h.bucket_count);
     // 1 half buckets, one full bucket
-    assert_eq!(h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len());
+    assert_eq!(h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len() as u32);
     assert_eq!(0, h.sub_bucket_half_count_magnitude);
     assert_eq!((2 - 1) << 62, h.sub_bucket_mask);
     // didn't shift off too much
@@ -238,7 +238,7 @@ fn init_fields_max_value_max_unit_magnitude_max_precision() {
     // 2^1 * 2^63 = 2^64, so 2 buckets.
     assert_eq!(2, h.bucket_count);
     // 1 half buckets, one full bucket
-    assert_eq!(h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len());
+    assert_eq!(h.sub_bucket_half_count + h.sub_bucket_count, h.counts.len() as u32);
     assert_eq!(17, h.sub_bucket_half_count_magnitude);
     assert_eq!(((1 << 18) - 1) << 45, h.sub_bucket_mask);
     // didn't shift off too much
@@ -265,7 +265,7 @@ fn new_err_high_not_double_low() {
 }
 
 #[cfg(test)]
-fn histo64(lowest_discernible_value: u64, highest_trackable_value: u64, num_significant_digits: u32)
+fn histo64(lowest_discernible_value: u64, highest_trackable_value: u64, num_significant_digits: u8)
            -> Histogram<u64> {
     Histogram::<u64>::new_with_bounds(lowest_discernible_value, highest_trackable_value,
                                       num_significant_digits).unwrap()

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -28,7 +28,7 @@ struct Loaded {
 }
 
 const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
-const SIGFIG: u32 = 3;
+const SIGFIG: u8 = 3;
 const EINTERVAL: u64 = 10000; /* 10 msec expected EINTERVAL */
 const SCALEF: u64 = 512;
 

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -28,6 +28,7 @@ struct Loaded {
 }
 
 const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
+// Store up to 2 * 10^3 in single-unit precision. Can be 5 at most.
 const SIGFIG: u8 = 3;
 const EINTERVAL: u64 = 10000; /* 10 msec expected EINTERVAL */
 const SCALEF: u64 = 512;

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -36,6 +36,7 @@ fn verify_max<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) -> bool {
 }
 
 const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
+// Store up to 2 * 10^3 in single-unit precision. Can be 5 at most.
 const SIGFIG: u8 = 3;
 const TEST_VALUE_LEVEL: u64 = 4;
 

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -2,6 +2,9 @@
 
 extern crate hdrsample;
 extern crate num;
+extern crate rand;
+
+use self::rand::Rng;
 
 use hdrsample::Histogram;
 use std::borrow::Borrow;
@@ -33,7 +36,7 @@ fn verify_max<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) -> bool {
 }
 
 const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
-const SIGFIG: u32 = 3;
+const SIGFIG: u8 = 3;
 const TEST_VALUE_LEVEL: u64 = 4;
 
 #[test]
@@ -394,4 +397,51 @@ fn scaled_set_to() {
 
     h2.set_to(&h1).unwrap();
     are_equal(&h1, &h2);
+}
+
+
+#[test]
+fn random_write_full_value_range_precision_5_no_panic() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 5).unwrap();
+
+    let mut rng = rand::weak_rng();
+
+    for _ in 0..1_000_000 {
+        let mut r: u64 = rng.gen();
+        if r == 0 {
+            r = 1;
+        }
+
+        h.record(r).unwrap();
+    }
+}
+
+
+#[test]
+fn random_write_full_value_range_precision_0_no_panic() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 0).unwrap();
+
+    let mut rng = rand::weak_rng();
+
+    for _ in 0..1_000_000 {
+        let mut r: u64 = rng.gen();
+        if r == 0 {
+            r = 1;
+        }
+
+        h.record(r).unwrap();
+    }
+}
+
+#[test]
+fn random_write_middle_of_value_range_precision_3_no_panic() {
+    let low = 1_000;
+    let high = 1_000_000_000;
+    let mut h = Histogram::<u64>::new_with_bounds(low, high, 3).unwrap();
+
+    let mut rng = rand::weak_rng();
+
+    for _ in 0..1_000_000 {
+        h.record(rng.gen_range(low, high + 1)).unwrap();
+    }
 }


### PR DESCRIPTION
Size shrinks from 144 bytes (according to std::mem::size_of) to 112
on a 64-bit system.

I'm not done poring over these changes to increase my confidence that nothing is broken, but I figured I might as well get it in front of your eyes sooner rather than later.

I added some tests that write random values in a couple of different configurations because early on in these changes I hit some panics due to overflow, etc, and I wanted a little insurance that I'd solved them all. 

Also, adding `rand` for the random tests exposed some Cargo sadness. Out of the box, that wouldn't build for me because `num` and `rand` had a version clash (fixed with `cargo update`). Because Cargo.lock isn't version controlled, now we're in a situation where it builds for me and probably doesn't for you. I know crates.io suggests not version controlling Cargo.lock, but I think that's a mistake, and I wish they wouldn't suggest that, because now we have an inconsistent build. Not checking in the lockfile coupled with Cargo's default of sneakily not using exact matches for versions is a recipe for exactly this situation. :( Are you open to checking in Cargo.lock? Otherwise, for instance, we can't trust a CI build, let alone both build the same revision successfully / identically.