### PR TITLE
Simplify equivalent range calculation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1239,16 +1239,7 @@ impl<T: Counter> Histogram<T> {
     /// any two equivalent values are counted in a common total count.
     pub fn equivalent_range(&self, value: u64) -> u64 {
         let bucket_index = self.bucket_for(value);
-        let sub_bucket_index = self.sub_bucket_for(value, bucket_index);
-        // calculate distance to next value
-        // TODO when is sub_bucket_index >= sub_bucket_count?
-        1_u64 <<
-        (self.unit_magnitude +
-         if sub_bucket_index >= self.sub_bucket_count {
-            bucket_index + 1
-        } else {
-            bucket_index
-        })
+        1_u64 << self.unit_magnitude + bucket_index
     }
 
     // ********************************************************************************************

--- a/src/tests/value_calculation.rs
+++ b/src/tests/value_calculation.rs
@@ -9,6 +9,7 @@ fn equivalent_range_unit_magnitude_0() {
     assert_eq!(1, h.equivalent_range(1023));
     // first in top half
     assert_eq!(1, h.equivalent_range(1024));
+    assert_eq!(1, h.equivalent_range(1025));
     // last in top half
     assert_eq!(1, h.equivalent_range(2047));
     // first in 2nd bucket


### PR DESCRIPTION
Gil agreed that sub bucket index is, in fact, never greater than count. Probably a leftover from a much earlier version of the logic where the halves of the bucket were expressed differently.

Fixed upstream too: 
- https://github.com/HdrHistogram/HdrHistogram/commit/c458630d7060f04668da2b5cf1c5603b37d7bfea
- https://github.com/HdrHistogram/HdrHistogram/commit/45a56bb87960c5a8c46f0ab9222ac48c3c9850bb