### PR TITLE
Allow optional serialization of Histogram

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,13 @@ travis-ci = { repository = "jonhoo/hdrsample" }
 [features]
 #benchmark = ["criterion"]
 benchmark = [] # for crates.io publication
+serde-serialize = ["serde", "serde_derive"]
 
 [dependencies]
 num = "0.1"
+rustc-serialize = { optional = true, version = "0.3" }
+serde = { optional = true, version = "0.9" }
+serde_derive = { optional = true, version = "0.9" }
 #criterion = { git = "https://github.com/japaric/criterion.rs.git", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ not (yet) been implemented:
    `DoubleHistogram` features are supported.
  - The `Recorder` feature of HdrHistogram.
  - Value shifting ("normalization").
- - Histogram serialization and encoding/decoding.
  - Timestamps and tags.
  - Textual output methods. These seem almost orthogonal to HdrSample, though it might be
    convenient if we implemented some relevant traits (CSV, JSON, and possibly simple

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,13 @@
 
 extern crate num;
 
+#[cfg(feature = "rustc-serialize")]
+extern crate rustc_serialize;
+
+#[cfg(feature = "serde-serialize")]
+#[macro_use]
+extern crate serde_derive;
+
 use std::borrow::Borrow;
 use std::cmp;
 use std::ops::{Index, IndexMut, AddAssign, SubAssign};
@@ -204,6 +211,8 @@ impl<T> Counter for T
 /// = 2048 * 2^(k-1)`, which is the k-1'th bucket's end. So, we would use the previous bucket
 /// for those lower values as it has better precision.
 ///
+#[cfg_attr(feature = "rustc-serialize",  derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize",  derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Histogram<T: Counter> {
     auto_resize: bool,


### PR DESCRIPTION
Serialization can be derived via either serde or rustc-serialize
depending upon feature flags.

To enable serialization via serde:
cli: `cargo build --features "serde-serialize"`
Cargo.toml: `features = ["rustc-serialize"]`

To enable serialization via rustc-serialize:
cli: `cargo build --features "rustc-serialize"`
Cargo.toml: `features = ["serde-serialize"]`

Also remove TODO for serialization/encoding from README.md