### PR TITLE
Do restat calculations during deserialization

### DIFF
--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -14,3 +14,9 @@ fn new_err_high_not_double_low() {
     let res = Histogram::<u64>::new_with_bounds(10, 15, 0);
     assert_eq!(CreationError::HighLessThanTwiceLow, res.unwrap_err());
 }
+
+#[test]
+fn correct_original_min() {
+    // until we get const fns, make sure workaround is correct
+    assert_eq!(u64::max_value(), super::ORIGINAL_MIN);
+}


### PR DESCRIPTION
Nets about a 25% performance boost. It's now about as fast as the Java implementation (until that one gets this optimization, anyway).

master

```
test deserialize_large_dense   ... bench:  26,229,050 ns/iter (+/- 787,846)
test deserialize_large_sparse  ... bench:  24,596,598 ns/iter (+/- 544,460)
test deserialize_medium_dense  ... bench:     132,117 ns/iter (+/- 3,301)
test deserialize_medium_sparse ... bench:     118,459 ns/iter (+/- 39,156)
test deserialize_small_dense   ... bench:       9,383 ns/iter (+/- 273)
test deserialize_small_sparse  ... bench:       4,055 ns/iter (+/- 63)
test deserialize_tiny_dense    ... bench:       2,688 ns/iter (+/- 144)
test deserialize_tiny_sparse   ... bench:       1,242 ns/iter (+/- 49)
```

this branch

```
test deserialize_large_dense   ... bench:  19,613,987 ns/iter (+/- 622,243)
test deserialize_large_sparse  ... bench:  17,943,651 ns/iter (+/- 962,566)
test deserialize_medium_dense  ... bench:      89,598 ns/iter (+/- 2,846)
test deserialize_medium_sparse ... bench:      77,555 ns/iter (+/- 3,188)
test deserialize_small_dense   ... bench:       7,685 ns/iter (+/- 237)
test deserialize_small_sparse  ... bench:       2,557 ns/iter (+/- 76)
test deserialize_tiny_dense    ... bench:       2,016 ns/iter (+/- 39)
test deserialize_tiny_sparse   ... bench:         790 ns/iter (+/- 13)
```
