### PR TITLE
Count saturates

### DIFF
--- a/benches/record.rs
+++ b/benches/record.rs
@@ -1,0 +1,145 @@
+#![feature(test)]
+
+extern crate hdrsample;
+extern crate rand;
+extern crate test;
+
+use hdrsample::*;
+use self::rand::Rng;
+use self::test::Bencher;
+
+#[bench]
+fn record_precalc_random_values_with_1_count_u64(b: &mut Bencher) {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+    let mut indices = Vec::<u64>::new();
+    let mut rng = rand::weak_rng();
+
+    // same value approach as record_precalc_random_values_with_max_count_u64 so that
+    // they are comparable
+
+    for _ in 0..1000_000 {
+        indices.push(rng.gen());
+    }
+
+    b.iter(|| {
+        for i in indices.iter() {
+            // u64 counts, won't overflow
+            h.record(*i).unwrap()
+        }
+    })
+}
+
+#[bench]
+fn record_precalc_random_values_with_max_count_u64(b: &mut Bencher) {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+    let mut indices = Vec::<u64>::new();
+    let mut rng = rand::weak_rng();
+
+    // store values in an array and re-use so we can be sure to hit the overflow case
+
+    for _ in 0..1000_000 {
+        let r = rng.gen();
+        indices.push(r);
+        h.record_n(r, u64::max_value()).unwrap();
+    }
+
+    b.iter(|| {
+        for i in indices.iter() {
+            // all values are already at u64
+            h.record(*i).unwrap()
+        }
+    })
+}
+
+#[bench]
+fn record_random_values_with_1_count_u64(b: &mut Bencher) {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+    let mut rng = rand::weak_rng();
+
+    // This should be *slower* than the benchmarks above where we pre-calculate the values
+    // outside of the hot loop. If it isn't, then those measurements are likely spurious.
+
+    b.iter(|| {
+        for _ in 0..1000_000 {
+            h.record(rng.gen()).unwrap()
+        }
+    })
+}
+
+#[bench]
+fn add_precalc_random_value_1_count_same_dimensions_u64(b: &mut Bencher) {
+    do_add_benchmark(b, 1, || { Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap() })
+}
+
+#[bench]
+fn add_precalc_random_value_max_count_same_dimensions_u64(b: &mut Bencher) {
+    do_add_benchmark(b, u64::max_value(), || { Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap() })
+}
+
+#[bench]
+fn add_precalc_random_value_1_count_different_precision_u64(b: &mut Bencher) {
+    do_add_benchmark(b, 1, || { Histogram::<u64>::new_with_bounds(1, u64::max_value(), 2).unwrap() })
+}
+
+#[bench]
+fn add_precalc_random_value_max_count_different_precision_u64(b: &mut Bencher) {
+    do_add_benchmark(b, u64::max_value(), || { Histogram::<u64>::new_with_bounds(1, u64::max_value(), 2).unwrap() })
+}
+
+#[bench]
+fn subtract_precalc_random_value_1_count_same_dimensions_u64(b: &mut Bencher) {
+    do_subtract_benchmark(b, 1, || { Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap() })
+}
+
+// can't do subtraction with max count because it will error after the first iteration because
+// subtrahend count exceeds minuend. Similarly, when subtracting a different precision, the same
+// issue happens because the smallest equivalent value in the lower precision can map to a different
+// bucket in higher precision so we cannot easily pre-populate.
+
+fn do_subtract_benchmark<F: Fn() -> Histogram<u64>>(b: &mut Bencher, count_at_each_addend_value: u64, addend_factory: F) {
+    let mut accum = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+    let mut subtrahends = Vec::new();
+    let mut rng = rand::weak_rng();
+
+    for _ in 0..1000 {
+        let mut h = addend_factory();
+
+        for _ in 0..1000 {
+            let r = rng.gen();
+            h.record_n(r, count_at_each_addend_value).unwrap();
+            // ensure there's a count to subtract from
+            accum.record_n(r, u64::max_value()).unwrap();
+        }
+
+        subtrahends.push(h);
+    }
+
+    b.iter(|| {
+        for h in subtrahends.iter() {
+            accum.subtract(h).unwrap();
+        }
+    })
+}
+
+fn do_add_benchmark<F: Fn() -> Histogram<u64>>(b: &mut Bencher, count_at_each_addend_value: u64, addend_factory: F) {
+    let mut accum = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+    let mut addends = Vec::new();
+    let mut rng = rand::weak_rng();
+
+    for _ in 0..1000 {
+        let mut h = addend_factory();
+
+        for _ in 0..1000 {
+            let r = rng.gen();
+            h.record_n(r, count_at_each_addend_value).unwrap();
+        }
+
+        addends.push(h);
+    }
+
+    b.iter(|| {
+        for h in addends.iter() {
+            accum.add(h).unwrap();
+        }
+    })
+}

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -159,6 +159,7 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
                     }
 
                     // maintain total count so we can yield percentiles
+                    // TODO overflow
                     self.total_count_to_index = self.total_count_to_index + count.to_u64().unwrap();
 
                     // make sure we don't add this index again

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -70,7 +70,6 @@ fn serialize_roundtrip_all_zeros() {
 
     assert_eq!(orig.total_count, deser.total_count);
     assert_eq!(orig.counts, deser.counts);
-
 }
 
 #[test]


### PR DESCRIPTION
I'd intended to do this later but it got in the way of benchmarks for deserialization to panic whenever things overflowed.

There are more overflows to handle (TODOs added) but they aren't inhibiting me so I left them for later. Each one needs a benchmark and tests, so they take a little time. 

Fortunately, this change has no effect whatsoever on performance, at least as far as I could measure. This is a somewhat tricky thing to benchmark because the thing measured is significantly faster than, say, random number generation, so I did the best I could by precalculating numbers to record (or histograms to add/subtract) and then simply iterating across that vec in the hot loop.