### PR TITLE
Simplify overflowing_add in median_equivalent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1252,11 +1252,9 @@ impl<T: Counter> Histogram<T> {
     ///
     /// Note that the return value is capped at `u64::max_value()`.
     pub fn median_equivalent(&self, value: u64) -> u64 {
-        // TODO isn't this just saturating?
-        match self.lowest_equivalent(value).overflowing_add(self.equivalent_range(value) >> 1) {
-            (_, of) if of => u64::max_value(),
-            (v, _) => v,
-        }
+        // adding half of the range to the bottom of the range shouldn't overflow
+        self.lowest_equivalent(value).checked_add(self.equivalent_range(value) >> 1)
+            .expect("median equivalent should not overflow")
     }
 
     /// Get the next value that is *not* equivalent to the given value within the histogram's

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -301,6 +301,15 @@ fn median_equivalent() {
 }
 
 #[test]
+fn median_equivalent_doesnt_panic_at_extremes() {
+    let h = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+    let _ = h.median_equivalent(u64::max_value());
+    let _ = h.median_equivalent(u64::max_value() - 1);
+    let _ = h.median_equivalent(0);
+    let _ = h.median_equivalent(1);
+}
+
+#[test]
 fn scaled_median_equivalent() {
     let h = Histogram::<u64>::new_with_bounds(1024, TRACKABLE_MAX, SIGFIG).unwrap();
     assert_eq!(h.median_equivalent(1024 * 4), 1024 * 4 + 512);


### PR DESCRIPTION
It looks like in fact that logic can (should) never overflow, so use checked_add instead.

I couldn't think of how that could overflow; am I missing some scenario that guided you to implement overflow handling in the first place?