### PR TITLE
Deserialize optimizations

### DIFF
--- a/src/serialization/benchmarks.rs
+++ b/src/serialization/benchmarks.rs
@@ -2,7 +2,7 @@ extern crate rand;
 extern crate test;
 
 use super::v2_serializer::varint_write;
-use super::deserializer::varint_read;
+use super::deserializer::{varint_read, varint_read_slice};
 use std::io::Cursor;
 use self::rand::distributions::range::Range;
 use self::rand::distributions::IndependentSample;
@@ -10,37 +10,52 @@ use self::test::Bencher;
 
 #[bench]
 fn varint_write_rand(b: &mut Bencher) {
-    do_varint_write_rand(b, 1000_000, Range::new(0, u64::max_value()))
+    do_varint_write_rand(b, Range::new(0, u64::max_value()))
 }
 
 #[bench]
 fn varint_write_rand_1_byte(b: &mut Bencher) {
-    do_varint_write_rand(b, 1000_000, Range::new(0, 128))
+    do_varint_write_rand(b, Range::new(0, 128))
 }
 
 #[bench]
 fn varint_write_rand_9_bytes(b: &mut Bencher) {
-    do_varint_write_rand(b, 1000_000, Range::new(1 << 56, u64::max_value()))
+    do_varint_write_rand(b, Range::new(1 << 56, u64::max_value()))
 }
 
 #[bench]
 fn varint_read_rand(b: &mut Bencher) {
-    do_varint_read_rand(b, 1000_000, Range::new(0, u64::max_value()))
+    do_varint_read_rand(b, Range::new(0, u64::max_value()))
 }
 
 #[bench]
 fn varint_read_rand_1_byte(b: &mut Bencher) {
-    do_varint_read_rand(b, 1000_000, Range::new(0, 128))
+    do_varint_read_rand(b, Range::new(0, 128))
 }
 
 #[bench]
 fn varint_read_rand_9_byte(b: &mut Bencher) {
-    do_varint_read_rand(b, 1000_000, Range::new(1 << 56, u64::max_value()))
+    do_varint_read_rand(b, Range::new(1 << 56, u64::max_value()))
 }
 
-fn do_varint_write_rand(b: &mut Bencher, num: usize, range: Range<u64>) {
-    let mut rng = rand::weak_rng();
+#[bench]
+fn varint_read_slice_rand(b: &mut Bencher) {
+    do_varint_read_slice_rand(b, Range::new(0, u64::max_value()))
+}
 
+#[bench]
+fn varint_read_slice_rand_1_byte(b: &mut Bencher) {
+    do_varint_read_slice_rand(b, Range::new(0, 128))
+}
+
+#[bench]
+fn varint_read_slice_rand_9_byte(b: &mut Bencher) {
+    do_varint_read_slice_rand(b, Range::new(1 << 56, u64::max_value()))
+}
+
+fn do_varint_write_rand(b: &mut Bencher, range: Range<u64>) {
+    let mut rng = rand::weak_rng();
+    let num = 1000_000;
     let mut vec: Vec<u64> = Vec::new();
 
     for _ in 0..num {
@@ -55,9 +70,9 @@ fn do_varint_write_rand(b: &mut Bencher, num: usize, range: Range<u64>) {
     });
 }
 
-fn do_varint_read_rand(b: &mut Bencher, num: usize, range: Range<u64>) {
+fn do_varint_read_rand(b: &mut Bencher, range: Range<u64>) {
     let mut rng = rand::weak_rng();
-
+    let num = 1000_000;
     let mut vec = Vec::new();
     vec.resize(9 * num, 0);
     let mut bytes_written = 0;
@@ -70,6 +85,29 @@ fn do_varint_read_rand(b: &mut Bencher, num: usize, range: Range<u64>) {
         let mut cursor = Cursor::new(&vec);
         for _ in 0..num {
             let _ = varint_read(&mut cursor);
+        }
+    });
+}
+
+fn do_varint_read_slice_rand(b: &mut Bencher, range: Range<u64>) {
+    let mut rng = rand::weak_rng();
+    let num = 1000_000;
+    let mut vec = Vec::new();
+
+    vec.resize(9 * num, 0);
+    let mut bytes_written = 0;
+
+    for _ in 0..num {
+        bytes_written += varint_write(range.ind_sample(&mut rng), &mut vec[bytes_written..]);
+    }
+
+    b.iter(|| {
+        let mut input_index = 0;
+        // cheat a little bit: this will skip the last couple numbers, but that's why we do a
+        // million numbers. Losing the last few won't be measurable.
+        while input_index < bytes_written - 9 {
+            let (_, bytes_read) = varint_read_slice(&vec[input_index..(input_index + 9)]);
+            input_index += bytes_read;
         }
     });
 }

--- a/src/serialization/benchmarks.rs
+++ b/src/serialization/benchmarks.rs
@@ -4,36 +4,47 @@ extern crate test;
 use super::v2_serializer::varint_write;
 use super::deserializer::varint_read;
 use std::io::Cursor;
-use self::rand::Rng;
+use self::rand::distributions::range::Range;
+use self::rand::distributions::IndependentSample;
 use self::test::Bencher;
 
 #[bench]
-fn varint_write_rand_1_k(b: &mut Bencher) {
-    do_varint_write_rand(b, 1000)
+fn varint_write_rand(b: &mut Bencher) {
+    do_varint_write_rand(b, 1000_000, Range::new(0, u64::max_value()))
 }
 
 #[bench]
-fn varint_write_rand_1_m(b: &mut Bencher) {
-    do_varint_write_rand(b, 1000_000)
+fn varint_write_rand_1_byte(b: &mut Bencher) {
+    do_varint_write_rand(b, 1000_000, Range::new(0, 128))
 }
 
 #[bench]
-fn varint_read_rand_1_k(b: &mut Bencher) {
-    do_varint_read_rand(b, 1000)
+fn varint_write_rand_9_bytes(b: &mut Bencher) {
+    do_varint_write_rand(b, 1000_000, Range::new(1 << 56, u64::max_value()))
 }
 
 #[bench]
-fn varint_read_rand_1_m(b: &mut Bencher) {
-    do_varint_read_rand(b, 1000_000)
+fn varint_read_rand(b: &mut Bencher) {
+    do_varint_read_rand(b, 1000_000, Range::new(0, u64::max_value()))
 }
 
-fn do_varint_write_rand(b: &mut Bencher, num: usize) {
+#[bench]
+fn varint_read_rand_1_byte(b: &mut Bencher) {
+    do_varint_read_rand(b, 1000_000, Range::new(0, 128))
+}
+
+#[bench]
+fn varint_read_rand_9_byte(b: &mut Bencher) {
+    do_varint_read_rand(b, 1000_000, Range::new(1 << 56, u64::max_value()))
+}
+
+fn do_varint_write_rand(b: &mut Bencher, num: usize, range: Range<u64>) {
     let mut rng = rand::weak_rng();
 
     let mut vec: Vec<u64> = Vec::new();
 
     for _ in 0..num {
-        vec.push(rng.gen());
+        vec.push(range.ind_sample(&mut rng));
     }
 
     let mut buf = [0; 9];
@@ -44,7 +55,7 @@ fn do_varint_write_rand(b: &mut Bencher, num: usize) {
     });
 }
 
-fn do_varint_read_rand(b: &mut Bencher, num: usize) {
+fn do_varint_read_rand(b: &mut Bencher, num: usize, range: Range<u64>) {
     let mut rng = rand::weak_rng();
 
     let mut vec = Vec::new();
@@ -52,7 +63,7 @@ fn do_varint_read_rand(b: &mut Bencher, num: usize) {
     let mut bytes_written = 0;
 
     for _ in 0..num {
-        bytes_written += varint_write(rng.gen(), &mut vec[bytes_written..]);
+        bytes_written += varint_write(range.ind_sample(&mut rng), &mut vec[bytes_written..]);
     }
 
     b.iter(|| {

--- a/src/serialization/deserializer.rs
+++ b/src/serialization/deserializer.rs
@@ -230,7 +230,6 @@ fn low_7_bits(b: u8) -> u64 {
 
 #[inline]
 fn is_high_bit_set(b: u8) -> bool {
-    // TODO benchmark leading zeros rather than masking
     (b & 0x80) != 0
 }
 

--- a/src/serialization/deserializer.rs
+++ b/src/serialization/deserializer.rs
@@ -55,8 +55,6 @@ impl Deserializer {
     /// bytes already in slice or `Vec` form.
     pub fn deserialize<T: Counter, R: Read>(&mut self, reader: &mut R)
                                             -> Result<Histogram<T>, DeserializeError> {
-        // TODO benchmark minimizing read calls by reading into a fixed-size header buffer
-
         let cookie = reader.read_u32::<BigEndian>()?;
 
         if cookie != V2_COOKIE {

--- a/src/serialization/v2_serializer.rs
+++ b/src/serialization/v2_serializer.rs
@@ -151,56 +151,49 @@ pub fn varint_write(input: u64, buf: &mut [u8]) -> usize {
     if (input >> 7) == 0 {
         buf[0] = input as u8;
         return 1;
-    } else {
-        // set high bit because more bytes are coming, then next 7 bits of value.
-        buf[0] = 0x80 | ((input & 0x7F) as u8);
-        if shift_by_7s(input, 2) == 0 {
-            // All zero above bottom 2 chunks, this is the last byte, so no high bit
-            buf[1] = shift_by_7s(input, 1) as u8;
-            return 2;
-        } else {
-            buf[1] = nth_7b_chunk_with_high_bit(input, 1);
-            if shift_by_7s(input, 3) == 0 {
-                buf[2] = shift_by_7s(input, 2) as u8;
-                return 3;
-            } else {
-                buf[2] = nth_7b_chunk_with_high_bit(input, 2);
-                if shift_by_7s(input, 4) == 0 {
-                    buf[3] = shift_by_7s(input, 3) as u8;
-                    return 4;
-                } else {
-                    buf[3] = nth_7b_chunk_with_high_bit(input, 3);
-                    if shift_by_7s(input, 5) == 0 {
-                        buf[4] = shift_by_7s(input, 4) as u8;
-                        return 5;
-                    } else {
-                        buf[4] = nth_7b_chunk_with_high_bit(input, 4);
-                        if shift_by_7s(input, 6) == 0 {
-                            buf[5] = shift_by_7s(input, 5) as u8;
-                            return 6;
-                        } else {
-                            buf[5] = nth_7b_chunk_with_high_bit(input, 5);
-                            if shift_by_7s(input, 7) == 0 {
-                                buf[6] = shift_by_7s(input, 6) as u8;
-                                return 7;
-                            } else {
-                                buf[6] = nth_7b_chunk_with_high_bit(input, 6);
-                                if shift_by_7s(input, 8) == 0 {
-                                    buf[7] = shift_by_7s(input, 7) as u8;
-                                    return 8;
-                                } else {
-                                    buf[7] = nth_7b_chunk_with_high_bit(input, 7);
-                                    // special case: write last whole byte as is
-                                    buf[8] = (input >> 56) as u8;
-                                    return 9;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
+    // set high bit because more bytes are coming, then next 7 bits of value.
+    buf[0] = 0x80 | ((input & 0x7F) as u8);
+    if shift_by_7s(input, 2) == 0 {
+        // All zero above bottom 2 chunks, this is the last byte, so no high bit
+        buf[1] = shift_by_7s(input, 1) as u8;
+        return 2;
+    }
+    buf[1] = nth_7b_chunk_with_high_bit(input, 1);
+    if shift_by_7s(input, 3) == 0 {
+        buf[2] = shift_by_7s(input, 2) as u8;
+        return 3;
+    }
+    buf[2] = nth_7b_chunk_with_high_bit(input, 2);
+    if shift_by_7s(input, 4) == 0 {
+        buf[3] = shift_by_7s(input, 3) as u8;
+        return 4;
+    }
+    buf[3] = nth_7b_chunk_with_high_bit(input, 3);
+    if shift_by_7s(input, 5) == 0 {
+        buf[4] = shift_by_7s(input, 4) as u8;
+        return 5;
+    }
+    buf[4] = nth_7b_chunk_with_high_bit(input, 4);
+    if shift_by_7s(input, 6) == 0 {
+        buf[5] = shift_by_7s(input, 5) as u8;
+        return 6;
+    }
+    buf[5] = nth_7b_chunk_with_high_bit(input, 5);
+    if shift_by_7s(input, 7) == 0 {
+        buf[6] = shift_by_7s(input, 6) as u8;
+        return 7;
+    }
+    buf[6] = nth_7b_chunk_with_high_bit(input, 6);
+    if shift_by_7s(input, 8) == 0 {
+        buf[7] = shift_by_7s(input, 7) as u8;
+        return 8;
+    }
+    buf[7] = nth_7b_chunk_with_high_bit(input, 7);
+    // special case: write last whole byte as is
+    buf[8] = (input >> 56) as u8;
+    return 9;
+
 }
 
 /// input: a u64


### PR DESCRIPTION
On d042145 (master + better benchmarks):

```
test serialization::benchmarks::varint_read_rand          ... bench:  16,685,639 ns/iter (+/- 598,312)
test serialization::benchmarks::varint_read_rand_1_byte   ... bench:   2,196,483 ns/iter (+/- 49,426)
test serialization::benchmarks::varint_read_rand_9_byte   ... bench:  16,646,062 ns/iter (+/- 664,383)

test deserialize_large_dense   ... bench:  20,091,180 ns/iter (+/- 511,062)
test deserialize_large_sparse  ... bench:  18,168,099 ns/iter (+/- 463,694)
test deserialize_medium_dense  ... bench:      90,360 ns/iter (+/- 2,269)
test deserialize_medium_sparse ... bench:      79,285 ns/iter (+/- 995)
test deserialize_small_dense   ... bench:       7,996 ns/iter (+/- 145)
test deserialize_small_sparse  ... bench:       2,596 ns/iter (+/- 101)
test deserialize_tiny_dense    ... bench:       2,225 ns/iter (+/- 131)
test deserialize_tiny_sparse   ... bench:         950 ns/iter (+/- 38)
```

Now:

```
test serialization::benchmarks::varint_read_rand              ... bench:  16,280,846 ns/iter (+/- 465,194)
test serialization::benchmarks::varint_read_rand_1_byte       ... bench:   2,151,960 ns/iter (+/- 523,349)
test serialization::benchmarks::varint_read_rand_9_byte       ... bench:  16,428,241 ns/iter (+/- 1,376,795)
test serialization::benchmarks::varint_read_slice_rand        ... bench:   3,894,007 ns/iter (+/- 122,742)
test serialization::benchmarks::varint_read_slice_rand_1_byte ... bench:     695,675 ns/iter (+/- 6,541)
test serialization::benchmarks::varint_read_slice_rand_9_byte ... bench:   3,801,225 ns/iter (+/- 139,819)

test deserialize_large_dense   ... bench:  17,070,681 ns/iter (+/- 414,028)
test deserialize_large_sparse  ... bench:  16,197,753 ns/iter (+/- 460,545)
test deserialize_medium_dense  ... bench:      28,897 ns/iter (+/- 2,052)
test deserialize_medium_sparse ... bench:      22,117 ns/iter (+/- 747)
test deserialize_small_dense   ... bench:       3,811 ns/iter (+/- 77)
test deserialize_small_sparse  ... bench:       1,059 ns/iter (+/- 39)
test deserialize_tiny_dense    ... bench:       1,124 ns/iter (+/- 45)
test deserialize_tiny_sparse   ... bench:         357 ns/iter (+/- 14)
```

So, big wins on tiny and small histograms, less so on very big ones.

For comparison, I wrote some basic benchmarks for the Java impl:

SimpleSerializationBenchmark.largeSparseDecodeFromByteBuffer  thrpt   15     81.947 ±    7.669  ops/s
(or, about 12.2M ns, vs Rust's 16M)
SimpleSerializationBenchmark.medSparseDecodeFromByteBuffer    thrpt   15  13760.020 ±  724.801  ops/s
(72674ns, vs Rust's 22117)

So, we've got some room to improve on the largest histograms, but still a good 3x on the medium-precision ones that people are likely to use.