### PR TITLE
Fix occasional test failures caused by incorrect min value tracking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ const ORIGINAL_MAX: u64 = 0;
 /// of percentiles.
 pub trait Counter
     : num::Num + num::ToPrimitive + num::FromPrimitive + num::Saturating + num::CheckedSub
-    + num::CheckedAdd + Copy + PartialOrd<Self>{
+    + num::CheckedAdd + Copy + PartialOrd<Self> {
 }
 
 // auto-implement marker trait

--- a/src/serialization/deserializer.rs
+++ b/src/serialization/deserializer.rs
@@ -240,12 +240,11 @@ pub fn zig_zag_decode(encoded: u64) -> i64 {
 /// We need to perform the same logic in two different decode loops while carrying over a modicum
 /// of state.
 struct DecodeLoopState<T: Counter> {
-    dest_index:usize,
+    dest_index: usize,
     phantom: PhantomData<T>
 }
 
-impl <T: Counter> DecodeLoopState<T> {
-
+impl<T: Counter> DecodeLoopState<T> {
     fn new() -> DecodeLoopState<T> {
         DecodeLoopState {
             dest_index: 0,
@@ -266,10 +265,12 @@ impl <T: Counter> DecodeLoopState<T> {
             let count: T = T::from_i64(count_or_zeros)
                 .ok_or(DeserializeError::UnsuitableCounterType)?;
 
-            h.set_count_at_index(self.dest_index, count)
-                .map_err(|_| DeserializeError::EncodedArrayTooLong)?;
+            if count > T::zero() {
+                h.set_count_at_index(self.dest_index, count)
+                    .map_err(|_| DeserializeError::EncodedArrayTooLong)?;
 
-            restat_state.on_nonzero_count(self.dest_index, count);
+                restat_state.on_nonzero_count(self.dest_index, count);
+            }
 
             self.dest_index = self.dest_index.checked_add(1)
                 .ok_or(DeserializeError::UsizeTypeTooSmall)?;

--- a/src/serialization/v2_serializer.rs
+++ b/src/serialization/v2_serializer.rs
@@ -107,7 +107,8 @@ pub fn encode_counts<T: Counter>(h: &Histogram<T>, buf: &mut [u8]) -> Result<usi
         let count = unsafe { *(h.counts.get_unchecked(index)) };
         index += 1;
 
-        // Non-negative values are positive counts or 1 zero, negative values are repeated zeros.
+        // Non-negative values are counts for the respective value, negative values are skipping
+        // that many (absolute value) zero-count values.
 
         let mut zero_count = 0;
         if count == T::zero() {


### PR DESCRIPTION
While working on something else I implemented better test random number generation, and sure enough it uncovered a bug. It would cause the minimum value to be set too low with certain patterns of non-zero value counts.