### PR TITLE
V2 + Deflate serialization support with flate2's stream wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bench_private = [] # for enabling nightly-only feature(test) on the main crate t
 [dependencies]
 num = "0.1"
 byteorder = "1.0.0"
+flate2 = "0.2.17"
 #criterion = { git = "https://github.com/japaric/criterion.rs.git", optional = true }
 
 [dev-dependencies]

--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -9,107 +9,131 @@ use hdrsample::serialization::*;
 use self::rand::distributions::range::Range;
 use self::rand::distributions::IndependentSample;
 use self::test::Bencher;
-use std::io::Cursor;
+use std::io::{Cursor, Write};
+use std::fmt::Debug;
 
 #[bench]
-fn serialize_tiny_dense(b: &mut Bencher) {
+fn serialize_tiny_dense_v2(b: &mut Bencher) {
     // 256 + 3 * 128 = 640 counts
-    do_serialize_bench(b, 1, 2047, 2, 1.5)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, 2047, 2, 1.5)
 }
 
 #[bench]
-fn serialize_tiny_sparse(b: &mut Bencher) {
+fn serialize_tiny_sparse_v2(b: &mut Bencher) {
     // 256 + 3 * 128 = 640 counts
-    do_serialize_bench(b, 1, 2047, 2, 0.1)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, 2047, 2, 0.1)
 }
 
 #[bench]
-fn serialize_small_dense(b: &mut Bencher) {
+fn serialize_small_dense_v2(b: &mut Bencher) {
     // 2048 counts
-    do_serialize_bench(b, 1, 2047, 3, 1.5)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, 2047, 3, 1.5)
 }
 
 #[bench]
-fn serialize_small_sparse(b: &mut Bencher) {
+fn serialize_small_sparse_v2(b: &mut Bencher) {
     // 2048 counts
-    do_serialize_bench(b, 1, 2047, 3, 0.1)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, 2047, 3, 0.1)
 }
 
 #[bench]
-fn serialize_medium_dense(b: &mut Bencher) {
+fn serialize_medium_dense_v2(b: &mut Bencher) {
     // 56320 counts
-    do_serialize_bench(b, 1, u64::max_value(), 3, 1.5)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 3, 1.5)
 }
 
 #[bench]
-fn serialize_medium_sparse(b: &mut Bencher) {
+fn serialize_medium_sparse_v2(b: &mut Bencher) {
     // 56320 counts
-    do_serialize_bench(b, 1, u64::max_value(), 3, 0.1)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 3, 0.1)
 }
 
 #[bench]
-fn serialize_large_dense(b: &mut Bencher) {
+fn serialize_large_dense_v2(b: &mut Bencher) {
     // 6291456 buckets
-    do_serialize_bench(b, 1, u64::max_value(), 5, 1.5)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 5, 1.5)
 }
 
 #[bench]
-fn serialize_large_sparse(b: &mut Bencher) {
+fn serialize_large_sparse_v2(b: &mut Bencher) {
     // 6291456 buckets
-    do_serialize_bench(b, 1, u64::max_value(), 5, 0.1)
+    do_serialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 5, 0.1)
 }
 
 #[bench]
-fn deserialize_tiny_dense(b: &mut Bencher) {
+fn serialize_large_dense_v2_deflate(b: &mut Bencher) {
+    // 6291456 buckets
+    do_serialize_bench(b, &mut V2DeflateSerializer::new(), 1, u64::max_value(), 5, 1.5)
+}
+
+#[bench]
+fn serialize_large_sparse_v2_deflate(b: &mut Bencher) {
+    // 6291456 buckets
+    do_serialize_bench(b, &mut V2DeflateSerializer::new(), 1, u64::max_value(), 5, 0.1)
+}
+
+#[bench]
+fn deserialize_tiny_dense_v2(b: &mut Bencher) {
     // 256 + 3 * 128 = 640 counts
-    do_deserialize_bench(b, 1, 2047, 2, 1.5)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, 2047, 2, 1.5)
 }
 
 #[bench]
-fn deserialize_tiny_sparse(b: &mut Bencher) {
+fn deserialize_tiny_sparse_v2(b: &mut Bencher) {
     // 256 + 3 * 128 = 640 counts
-    do_deserialize_bench(b, 1, 2047, 2, 0.1)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, 2047, 2, 0.1)
 }
 
 #[bench]
-fn deserialize_small_dense(b: &mut Bencher) {
+fn deserialize_small_dense_v2(b: &mut Bencher) {
     // 2048 counts
-    do_deserialize_bench(b, 1, 2047, 3, 1.5)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, 2047, 3, 1.5)
 }
 
 #[bench]
-fn deserialize_small_sparse(b: &mut Bencher) {
+fn deserialize_small_sparse_v2(b: &mut Bencher) {
     // 2048 counts
-    do_deserialize_bench(b, 1, 2047, 3, 0.1)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, 2047, 3, 0.1)
 }
 
 #[bench]
-fn deserialize_medium_dense(b: &mut Bencher) {
+fn deserialize_medium_dense_v2(b: &mut Bencher) {
     // 56320 counts
-    do_deserialize_bench(b, 1, u64::max_value(), 3, 1.5)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 3, 1.5)
 }
 
 #[bench]
-fn deserialize_medium_sparse(b: &mut Bencher) {
+fn deserialize_medium_sparse_v2(b: &mut Bencher) {
     // 56320 counts
-    do_deserialize_bench(b, 1, u64::max_value(), 3, 0.1)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 3, 0.1)
 }
 
 #[bench]
-fn deserialize_large_dense(b: &mut Bencher) {
+fn deserialize_large_dense_v2(b: &mut Bencher) {
     // 6291456 buckets
-    do_deserialize_bench(b, 1, u64::max_value(), 5, 1.5)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 5, 1.5)
 }
 
 #[bench]
-fn deserialize_large_sparse(b: &mut Bencher) {
+fn deserialize_large_sparse_v2(b: &mut Bencher) {
     // 6291456 buckets
-    do_deserialize_bench(b, 1, u64::max_value(), 5, 0.1)
+    do_deserialize_bench(b, &mut V2Serializer::new(), 1, u64::max_value(), 5, 0.1)
 }
 
+#[bench]
+fn deserialize_large_dense_v2_deflate(b: &mut Bencher) {
+    // 6291456 buckets
+    do_deserialize_bench(b, &mut V2DeflateSerializer::new(), 1, u64::max_value(), 5, 1.5)
+}
 
-fn do_serialize_bench(b: &mut Bencher, low: u64, high: u64, digits: u8, fraction_of_counts_len: f64) {
-    let mut s = V2Serializer::new();
+#[bench]
+fn deserialize_large_sparse_v2_deflate(b: &mut Bencher) {
+    // 6291456 buckets
+    do_deserialize_bench(b, &mut V2DeflateSerializer::new(), 1, u64::max_value(), 5, 0.1)
+}
+
+fn do_serialize_bench<S>(b: &mut Bencher, s: &mut S, low: u64, high: u64, digits: u8, fraction_of_counts_len: f64)
+    where S: TestOnlyHypotheticalSerializerInterface {
     let mut h = Histogram::<u64>::new_with_bounds(low, high, digits).unwrap();
     let random_counts = (fraction_of_counts_len * h.len() as f64) as usize;
     let mut vec = Vec::with_capacity(random_counts);
@@ -128,8 +152,8 @@ fn do_serialize_bench(b: &mut Bencher, low: u64, high: u64, digits: u8, fraction
     });
 }
 
-fn do_deserialize_bench(b: &mut Bencher, low: u64, high: u64, digits: u8, fraction_of_counts_len: f64) {
-    let mut s = V2Serializer::new();
+fn do_deserialize_bench<S>(b: &mut Bencher, s: &mut S, low: u64, high: u64, digits: u8, fraction_of_counts_len: f64)
+    where S: TestOnlyHypotheticalSerializerInterface {
     let mut h = Histogram::<u64>::new_with_bounds(low, high, digits).unwrap();
     let random_counts = (fraction_of_counts_len * h.len() as f64) as usize;
     let mut vec = Vec::with_capacity(random_counts);
@@ -148,4 +172,31 @@ fn do_deserialize_bench(b: &mut Bencher, low: u64, high: u64, digits: u8, fracti
         let mut cursor = Cursor::new(&vec);
         let _: Histogram<u64> = d.deserialize(&mut cursor).unwrap();
     });
+}
+
+// Maybe someday there will be an obvious right answer for what serialization should look like, at
+// least to the user, but for now we'll only take an easily reversible step towards that. There are
+// still several ways the serializer interfaces could change to achieve better performance, so
+// committing to anything right now would be premature.
+trait TestOnlyHypotheticalSerializerInterface {
+    type SerializeError: Debug;
+
+    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W)
+                                       -> Result<usize, Self::SerializeError>;
+}
+
+impl TestOnlyHypotheticalSerializerInterface for V2Serializer {
+    type SerializeError = V2SerializeError;
+
+    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
+        self.serialize(h, writer)
+    }
+}
+
+impl TestOnlyHypotheticalSerializerInterface for V2DeflateSerializer {
+    type SerializeError = V2DeflateSerializeError;
+
+    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
+        self.serialize(h, writer)
+    }
 }

--- a/src/serialization/serialization.rs
+++ b/src/serialization/serialization.rs
@@ -31,7 +31,9 @@
 //!
 //! V2 + DEFLATE is significantly slower to serialize (around 10x) but only a little bit slower to
 //! deserialize (less than 2x). YMMV depending on the compressibility of your histogram data, the
-//! speed of the underlying storage medium, etc.
+//! speed of the underlying storage medium, etc. Naturally, you can always compress at a later time:
+//! there's no reason why you couldn't serialize as V2 and then later re-serialize it as V2 +
+//! DEFLATE on another system (perhaps as a batch job) for better archival storage density.
 //!
 //! # API
 //!
@@ -88,11 +90,11 @@
 //!
 //! impl Serialize for V2HistogramWrapper {
 //!     fn serialize<S: Serializer>(&self, serializer: S) -> Result<(), ()> {
-//!         // not optimal to not re-use the vec and serializer, but it'll work
+//!         // Not optimal to not re-use the vec and serializer, but it'll work
 //!         let mut vec = Vec::new();
-//!         // pick the format you want to use
-//!
-//!         // map errors as appropriate for your use case
+//!         // Pick the serialization format you want to use. Here, we use plain V2, but V2 +
+//!         // DEFLATE is also available.
+//!         // Map errors as appropriate for your use case.
 //!         V2Serializer::new().serialize(&self.histogram, &mut vec)
 //!             .map_err(|_| ())?;
 //!         serializer.serialize_bytes(&vec)?;

--- a/src/serialization/serialization.rs
+++ b/src/serialization/serialization.rs
@@ -1,11 +1,12 @@
 //! # Serialization/deserialization
 //!
 //! The upstream Java project has established several different types of serialization. We have
-//! currently implemented one (the "V2" format, following the names used by the Java
-//! implementation), and will add others as time goes on. These formats are compact binary
-//! representations of the state of the histogram. They are intended to be used
-//! for archival or transmission to other systems for further analysis. A typical use case would be
-//! to periodically serialize a histogram, save it somewhere, and reset the histogram.
+//! currently implemented V2 and V2 + DEFLATE (following the names used by the Java implementation).
+//!
+//! These formats are compact binary representations of the state of the histogram. They are
+//! intended to be used for archival or transmission to other systems for further analysis. A
+//! typical use case would be to periodically serialize a histogram, save it somewhere, and reset
+//! the histogram.
 //!
 //! Histograms are designed to be added, subtracted, and otherwise manipulated, and an efficient
 //! storage format facilitates this. As an example, you might be capturing histograms once a minute
@@ -18,22 +19,25 @@
 //!
 //! # Performance concerns
 //!
-//! Serialization is quite fast; serializing a histogram that represents 1 to `u64::max_value()`
-//! with 3 digits of precision with tens of thousands of recorded counts takes about 40
-//! microseconds on an E5-1650v3 Xeon. Deserialization is about 3x slower, but that will improve as
-//! there are still some optimizations to perform.
+//! Serialization is quite fast; serializing a histogram in V2 format that represents 1 to
+//! `u64::max_value()` with 3 digits of precision with tens of thousands of recorded counts takes
+//! about 40 microseconds on an E5-1650v3 Xeon. Deserialization is about 3x slower, but that will
+//! improve as there are still some optimizations to perform.
 //!
 //! For the V2 format, the space used for a histogram will depend mainly on precision since higher
 //! precision will reduce the extent to which different values are grouped into the same bucket.
 //! Having a large value range (e.g. 1 to `u64::max_value()`) will not directly impact the size if
 //! there are many zero counts as zeros are compressed away.
 //!
+//! V2 + DEFLATE is significantly slower to serialize (around 10x) but only a little bit slower to
+//! deserialize (less than 2x). YMMV depending on the compressibility of your histogram data, the
+//! speed of the underlying storage medium, etc.
+//!
 //! # API
 //!
 //! Each serialization format has its own serializer struct, but since each format is reliably
 //! distinguishable from each other, there is only one `Deserializer` struct that will work for
-//! any of the formats this library implements. For now there is only one serializer
-//! (`V2Serializer`) but more will be added.
+//! any of the formats this library implements.
 //!
 //! Serializers and deserializers are intended to be re-used for many histograms. You can use them
 //! for one histogram and throw them away; it will just be less efficient as the cost of their
@@ -86,6 +90,8 @@
 //!     fn serialize<S: Serializer>(&self, serializer: S) -> Result<(), ()> {
 //!         // not optimal to not re-use the vec and serializer, but it'll work
 //!         let mut vec = Vec::new();
+//!         // pick the format you want to use
+//!
 //!         // map errors as appropriate for your use case
 //!         V2Serializer::new().serialize(&self.histogram, &mut vec)
 //!             .map_err(|_| ())?;
@@ -163,6 +169,7 @@
 //!
 
 extern crate byteorder;
+extern crate flate2;
 
 #[path = "tests.rs"]
 #[cfg(test)]
@@ -176,13 +183,19 @@ mod benchmarks;
 mod v2_serializer;
 pub use self::v2_serializer::{V2Serializer, V2SerializeError};
 
+#[path = "v2_deflate_serializer.rs"]
+mod v2_deflate_serializer;
+pub use self::v2_deflate_serializer::{V2DeflateSerializer, V2DeflateSerializeError};
+
 #[path = "deserializer.rs"]
 mod deserializer;
 pub use self::deserializer::{Deserializer, DeserializeError};
 
 const V2_COOKIE_BASE: u32 = 0x1c849303;
+const V2_COMPRESSED_COOKIE_BASE: u32 = 0x1c849304;
 
 const V2_COOKIE: u32 = V2_COOKIE_BASE | 0x10;
+const V2_COMPRESSED_COOKIE: u32 = V2_COMPRESSED_COOKIE_BASE | 0x10;
 
 const V2_HEADER_SIZE: usize = 40;
 

--- a/src/serialization/v2_deflate_serializer.rs
+++ b/src/serialization/v2_deflate_serializer.rs
@@ -1,0 +1,86 @@
+use super::super::{Counter, Histogram};
+use super::V2_COMPRESSED_COOKIE;
+use super::v2_serializer::{V2Serializer, V2SerializeError};
+use super::byteorder::{BigEndian, WriteBytesExt};
+use super::flate2::Compression;
+use std;
+use std::io::{ErrorKind, Write};
+use super::flate2::write::DeflateEncoder;
+
+/// Errors that occur during serialization.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum V2DeflateSerializeError {
+    /// The underlying serialization failed
+    InternalSerializationError(V2SerializeError),
+    /// An i/o operation failed.
+    IoError(ErrorKind)
+}
+
+impl std::convert::From<std::io::Error> for V2DeflateSerializeError {
+    fn from(e: std::io::Error) -> Self {
+        V2DeflateSerializeError::IoError(e.kind())
+    }
+}
+
+/// Serializer for the V2 + DEFLATE binary format.
+pub struct V2DeflateSerializer {
+    uncompressed_buf: Vec<u8>,
+    compressed_buf: Vec<u8>,
+    v2_serializer: V2Serializer
+}
+
+impl V2DeflateSerializer {
+    /// Create a new serializer.
+    pub fn new() -> V2DeflateSerializer {
+        V2DeflateSerializer {
+            uncompressed_buf: Vec::new(),
+            compressed_buf: Vec::new(),
+            v2_serializer: V2Serializer::new()
+        }
+    }
+
+    /// Serialize the histogram into the provided writer.
+    /// Returns the number of bytes written, or an error.
+    ///
+    /// Note that `Vec<u8>` is a reasonable `Write` implementation for simple usage.
+    pub fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W)
+                                           -> Result<usize, V2DeflateSerializeError> {
+        // TODO benchmark serializing in chunks rather than all at once: each uncompressed v2 chunk
+        // could be compressed and written to the compressed buf, possibly using an approach like
+        // that of https://github.com/jonhoo/hdrsample/issues/32#issuecomment-287583055.
+        // This would reduce the overall buffer size needed for plain v2 serialization, and be
+        // more cache friendly.
+
+        self.uncompressed_buf.clear();
+        self.compressed_buf.clear();
+        // TODO serialize directly into uncompressed_buf without the buffering inside v2_serializer
+        let uncompressed_len = self.v2_serializer.serialize(h, &mut self.uncompressed_buf)
+            .map_err(|e| V2DeflateSerializeError::InternalSerializationError(e))?;
+
+        debug_assert_eq!(self.uncompressed_buf.len(), uncompressed_len);
+
+        self.compressed_buf.write_u32::<BigEndian>(V2_COMPRESSED_COOKIE)?;
+        // placeholder for length
+        self.compressed_buf.write_u32::<BigEndian>(0)?;
+
+        // TODO pluggable compressors? configurable compression levels?
+        // TODO benchmark https://github.com/sile/libflate
+
+        {
+            // TODO reuse deflate buf, or switch to lower-level flate2::Compress
+            let mut compressor = DeflateEncoder::new(&mut self.compressed_buf, Compression::Default);
+            compressor.write_all(&self.uncompressed_buf[0..uncompressed_len])?;
+            let _ = compressor.finish()?;
+        };
+
+        // fill in length placeholder. Won't underflow since length is always at least 8, and won't
+        // overflow u32 as the largest array is about 6 million entries, so about 54MiB encoded (if
+        // counter is u64)
+        let total_compressed_len = self.compressed_buf.len();
+        (&mut self.compressed_buf[4..8]).write_u32::<BigEndian>((total_compressed_len as u32) - 8)?;
+
+        writer.write_all(&self.compressed_buf)?;
+
+        Ok(total_compressed_len)
+    }
+}

--- a/src/serialization/v2_serializer.rs
+++ b/src/serialization/v2_serializer.rs
@@ -42,6 +42,8 @@ impl V2Serializer {
     /// Note that `Vec<u8>` is a reasonable `Write` implementation for simple usage.
     pub fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W)
                                            -> Result<usize, V2SerializeError> {
+        // TODO benchmark encoding directly into target Vec
+
         self.buf.clear();
         let max_size = max_encoded_size(h).ok_or(V2SerializeError::UsizeTypeTooSmall)?;
         self.buf.reserve(max_size);


### PR DESCRIPTION
Performance isn't awful but it isn't great either. Compression is slow and there's not a lot we can do about that.

```
test deserialize_large_dense_v2          ... bench:  18,970,418 ns/iter (+/- 944,849)
test deserialize_large_dense_v2_deflate  ... bench:  23,991,379 ns/iter (+/- 1,329,386)
test deserialize_large_sparse_v2         ... bench:  17,710,620 ns/iter (+/- 1,145,763)
test deserialize_large_sparse_v2_deflate ... bench:  20,297,392 ns/iter (+/- 1,568,093)

test serialize_large_dense_v2            ... bench:   7,154,361 ns/iter (+/- 307,599)
test serialize_large_dense_v2_deflate    ... bench:  94,926,041 ns/iter (+/- 3,333,186)
test serialize_large_sparse_v2           ... bench:   6,570,606 ns/iter (+/- 639,558)
test serialize_large_sparse_v2_deflate   ... bench:  63,914,342 ns/iter (+/- 4,191,686)
```