### PR TITLE
Share internal serializer interface via the rather blunt means of include!()

### DIFF
--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -174,29 +174,4 @@ fn do_deserialize_bench<S>(b: &mut Bencher, s: &mut S, low: u64, high: u64, digi
     });
 }
 
-// Maybe someday there will be an obvious right answer for what serialization should look like, at
-// least to the user, but for now we'll only take an easily reversible step towards that. There are
-// still several ways the serializer interfaces could change to achieve better performance, so
-// committing to anything right now would be premature.
-trait TestOnlyHypotheticalSerializerInterface {
-    type SerializeError: Debug;
-
-    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W)
-                                       -> Result<usize, Self::SerializeError>;
-}
-
-impl TestOnlyHypotheticalSerializerInterface for V2Serializer {
-    type SerializeError = V2SerializeError;
-
-    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
-        self.serialize(h, writer)
-    }
-}
-
-impl TestOnlyHypotheticalSerializerInterface for V2DeflateSerializer {
-    type SerializeError = V2DeflateSerializeError;
-
-    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
-        self.serialize(h, writer)
-    }
-}
+include!("../src/serialization/test_serialize_trait.rs");

--- a/src/serialization/test_serialize_trait.rs
+++ b/src/serialization/test_serialize_trait.rs
@@ -1,0 +1,26 @@
+// Maybe someday there will be an obvious right answer for what serialization should look like, at
+// least to the user, but for now we'll only take an easily reversible step towards that. There are
+// still several ways the serializer interfaces could change to achieve better performance, so
+// committing to anything right now would be premature.
+trait TestOnlyHypotheticalSerializerInterface {
+    type SerializeError: Debug;
+
+    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W)
+                                       -> Result<usize, Self::SerializeError>;
+}
+
+impl TestOnlyHypotheticalSerializerInterface for V2Serializer {
+    type SerializeError = V2SerializeError;
+
+    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
+        self.serialize(h, writer)
+    }
+}
+
+impl TestOnlyHypotheticalSerializerInterface for V2DeflateSerializer {
+    type SerializeError = V2DeflateSerializeError;
+
+    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
+        self.serialize(h, writer)
+    }
+}

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -695,29 +695,4 @@ impl<R: Rng> Iterator for RandomVarintEncodedLengthIter<R> {
     }
 }
 
-// Maybe someday there will be an obvious right answer for what serialization should look like, at
-// least to the user, but for now we'll only take an easily reversible step towards that. There are
-// still several ways the serializer interfaces could change to achieve better performance, so
-// committing to anything right now would be premature.
-trait TestOnlyHypotheticalSerializerInterface {
-    type SerializeError: Debug;
-
-    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W)
-                                       -> Result<usize, Self::SerializeError>;
-}
-
-impl TestOnlyHypotheticalSerializerInterface for V2Serializer {
-    type SerializeError = V2SerializeError;
-
-    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
-        self.serialize(h, writer)
-    }
-}
-
-impl TestOnlyHypotheticalSerializerInterface for V2DeflateSerializer {
-    type SerializeError = V2DeflateSerializeError;
-
-    fn serialize<T: Counter, W: Write>(&mut self, h: &Histogram<T>, writer: &mut W) -> Result<usize, Self::SerializeError> {
-        self.serialize(h, writer)
-    }
-}
+include!("test_serialize_trait.rs");


### PR DESCRIPTION
Icky, but it gets the job done. `path` trickery ran afoul of needing to specify the `use` paths to various types differently in the two cases. I think I weakly prefer this to copy and paste, but not by much.