### PR TITLE
Split alter_n into dedicated add and subtract logic.

### DIFF
--- a/benches/record.rs
+++ b/benches/record.rs
@@ -128,15 +128,16 @@ fn do_subtract_benchmark<F: Fn() -> Histogram<u64>>(b: &mut Bencher, count_at_ea
             let r = rng.gen();
             h.record_n(r, count_at_each_addend_value).unwrap();
             // ensure there's a count to subtract from
-            accum.record_n(r, u64::max_value()).unwrap();
+            accum.record_n(r, count_at_each_addend_value).unwrap();
         }
 
         subtrahends.push(h);
     }
 
     b.iter(|| {
+        let mut clone = accum.clone();
         for h in subtrahends.iter() {
-            accum.subtract(h).unwrap();
+            clone.subtract(h).unwrap();
         }
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,30 +544,49 @@ impl<T: Counter> Histogram<T> {
 
         // make sure we can take the values in source
         let top = self.highest_equivalent(self.value_for(self.last()));
-        if top < other.max() {
-            if !self.auto_resize {
-                return Err(SubtractionError::SubtrahendValuesExceedMinuendRange);
-            }
-            self.resize(other.max());
+        if top < self.highest_equivalent(other.max()) {
+            return Err(SubtractionError::SubtrahendValuesExceedMinuendRange);
         }
+
+        let old_min_highest_equiv = self.highest_equivalent(self.min());
+        let old_max_lowest_equiv = self.lowest_equivalent(self.max());
+
+        // If total_count is at the max value, it may have saturated, so we must restat
+        let mut needs_restat = self.total_count == u64::max_value();
 
         for i in 0..other.len() {
             let other_count = other[i];
             if other_count != T::zero() {
                 let other_value = other.value_for(i);
-                if self.count_at(other_value).unwrap() < other_count {
-                    // TODO Perhaps we should saturating sub here? Or expose some form of
-                    // pluggability so users could choose to error or saturate? Both seem useful.
-                    // It's also sort of inconsistent with overflow, which now saturates.
-                    return Err(SubtractionError::SubtrahendCountExceedsMinuendCount);
+                {
+                    let mut_count = self.mut_at(other_value);
+
+                    if let Some(c) = mut_count {
+                        // TODO Perhaps we should saturating sub here? Or expose some form of
+                        // pluggability so users could choose to error or saturate? Both seem useful.
+                        // It's also sort of inconsistent with overflow, which now saturates.
+                        *c = (*c).checked_sub(&other_count)
+                            .ok_or(SubtractionError::SubtrahendCountExceedsMinuendCount)?;
+                    } else {
+                        panic!("Tried to subtract value outside of range: {}", other_value);
+                    }
                 }
-                self.alter_n(other_value, other_count, false).expect("value should fit by now");
+
+                // we might have just set the min / max to have zero count.
+                if other_value <= old_min_highest_equiv || other_value >= old_max_lowest_equiv {
+                    needs_restat = true;
+                }
+
+                if !needs_restat {
+                    // if we're not already going to recalculate everything, subtract from
+                    // total_count
+                    self.total_count = self.total_count.checked_sub(other_count.to_u64().unwrap())
+                        .expect("total count underflow on subtraction");
+                }
             }
         }
 
-        // With subtraction, the max and min_non_zero values could have changed:
-        if self.count_at(self.max()).unwrap() == T::zero() ||
-           self.count_at(self.min_nz()).unwrap() == T::zero() {
+        if needs_restat{
             let l = self.len();
             self.restat(l);
         }
@@ -775,60 +794,30 @@ impl<T: Counter> Histogram<T> {
     /// `count` is the number of occurrences of this value to record. Returns an error if `value`
     /// exceeds the highest trackable value and auto-resize is disabled.
     pub fn record_n(&mut self, value: u64, count: T) -> Result<(), ()> {
-        self.alter_n(value, count, true)
-    }
-
-    fn alter_n(&mut self, value: u64, count: T, add: bool) -> Result<(), ()> {
-        // TODO consider split out addition and subtraction cases; this isn't gaining much by
-        // unifying since we have to test all the cases anyway, and the TODO below is marking a case
-        // that might well be impossible but seems needed because of the (possibly false) symmetry
-        // with addition
-
-        // add=false is used by subtract(), which should have already aborted if underflow was
-        // possible
-
-        let success = if let Some(c) = self.mut_at(value) {
-            if add {
-                *c = (*c).saturating_add(count);
-            } else {
-                *c = (*c).checked_sub(&count).expect("count underflow on subtraction");
-            }
+        let recorded_without_resize = if let Some(c) = self.mut_at(value) {
+            *c = (*c).saturating_add(count);
             true
         } else {
             false
         };
 
-        if !success {
+        if !recorded_without_resize {
             if !self.auto_resize {
                 return Err(());
             }
 
             self.resize(value);
+            self.highest_trackable_value = self.highest_equivalent(self.value_for(self.last()));
 
             {
                 let c = self.mut_at(value).expect("value should fit after resize");
-                if add {
-                    // after resize, should be no possibility of overflow because this is a new slot
-                    *c = (*c).checked_add(&count).expect("count overflow after resize");
-                } else {
-                    // TODO Not sure this code path can ever be hit: if subtraction requires minuend
-                    // count to exceed subtrahend count for a given value, we shouldn't ever need
-                    // to resize to subtract.
-                    // Anyway, at the very least, we know it shouldn't underflow.
-                    *c = (*c).checked_sub(&count).expect("count underflow after resize");
-                }
+                // after resize, should be no possibility of overflow because this is a new slot
+                *c = (*c).checked_add(&count).expect("count overflow after resize");
             }
-
-            self.highest_trackable_value = self.highest_equivalent(self.value_for(self.last()));
         }
 
         self.update_min_max(value);
-        if add {
-            self.total_count = self.total_count.saturating_add(count.to_u64().unwrap());
-        } else {
-            self.total_count = self.total_count.checked_sub(count.to_u64().unwrap())
-                .expect("total count underflow on subtraction");
-        }
+        self.total_count = self.total_count.saturating_add(count.to_u64().unwrap());
         Ok(())
     }
 

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -9,7 +9,9 @@ use self::rand::Rng;
 use hdrsample::{Histogram, SubtractionError};
 use hdrsample::serialization::{V2Serializer, Deserializer};
 use std::borrow::Borrow;
+use std::cmp;
 use std::fmt;
+use num::Saturating;
 
 macro_rules! assert_near {
     ($a: expr, $b: expr, $tolerance: expr) => {{
@@ -34,6 +36,31 @@ fn verify_max<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) -> bool {
     } else {
         hist.max() == 0
     }
+}
+
+fn assert_min_max_count<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) {
+    let h = hist.borrow();
+    let mut min = None;
+    let mut max = None;
+    let mut total = 0;
+    for i in 0..h.len() {
+        let value = h.value_for(i);
+        let count = h.count_at(value).unwrap();
+        if count == T::zero() {
+            continue;
+        }
+
+        min = Some(cmp::min(min.unwrap_or(u64::max_value()), value));
+        max = Some(cmp::max(max.unwrap_or(0), value));
+        total = total.saturating_add(count.to_u64().unwrap());
+    }
+
+    let min = min.map(|m| h.lowest_equivalent(m)).unwrap_or(0);
+    let max = max.map(|m| h.highest_equivalent(m)).unwrap_or(0);
+
+    assert_eq!(min, h.min());
+    assert_eq!(max, h.max());
+    assert_eq!(total, h.count());
 }
 
 const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
@@ -168,7 +195,7 @@ fn add() {
 }
 
 #[test]
-fn subtract() {
+fn subtract_after_add() {
     let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
     let mut h2 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
 
@@ -192,15 +219,70 @@ fn subtract() {
     assert_eq!(h1.count_at(1000 * TEST_VALUE_LEVEL), Ok(2));
     assert_eq!(h1.count(), 4);
 
-    // Subtracting down to zero counts should work:
-    let x = h1.clone();
-    h1 -= &x;
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_to_zero_counts() {
+    let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+
+    h1 += TEST_VALUE_LEVEL;
+    h1 += 1000 * TEST_VALUE_LEVEL;
+
+    assert_eq!(h1.count_at(TEST_VALUE_LEVEL), Ok(1));
+    assert_eq!(h1.count_at(1000 * TEST_VALUE_LEVEL), Ok(1));
+    assert_eq!(h1.count(), 2);
+
+    let clone = h1.clone();
+    h1.subtract(&clone).unwrap();
     assert_eq!(h1.count_at(TEST_VALUE_LEVEL), Ok(0));
     assert_eq!(h1.count_at(1000 * TEST_VALUE_LEVEL), Ok(0));
     assert_eq!(h1.count(), 0);
 
-    // But subtracting down to negative counts should not:
-    assert!(h1.subtract(&h2).is_err());
+    assert_min_max_count(h1);
+}
+
+#[test]
+fn subtract_to_negative_counts_error() {
+    let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+
+    h1 += TEST_VALUE_LEVEL;
+    h1 += 1000 * TEST_VALUE_LEVEL;
+    h2.record_n(TEST_VALUE_LEVEL, 2).unwrap();
+    h2.record_n(1000 * TEST_VALUE_LEVEL, 2).unwrap();
+
+    assert_eq!(SubtractionError::SubtrahendCountExceedsMinuendCount, h1.subtract(&h2).unwrap_err());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_subtrahend_values_outside_minuend_range_error() {
+    let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+
+    h1 += TEST_VALUE_LEVEL;
+    h1 += 1000 * TEST_VALUE_LEVEL;
+
+    let mut big = Histogram::<u64>::new_with_max(2 * TRACKABLE_MAX, SIGFIG).unwrap();
+    big += TEST_VALUE_LEVEL;
+    big += 1000 * TEST_VALUE_LEVEL;
+    big += 2 * TRACKABLE_MAX;
+
+    assert_eq!(SubtractionError::SubtrahendValuesExceedMinuendRange, h1.subtract(&big).unwrap_err());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(big);
+}
+
+#[test]
+fn subtract_values_inside_minuend_range_works() {
+    let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+
+    h1 += TEST_VALUE_LEVEL;
+    h1 += 1000 * TEST_VALUE_LEVEL;
 
     let mut big = Histogram::<u64>::new_with_max(2 * TRACKABLE_MAX, SIGFIG).unwrap();
     big += TEST_VALUE_LEVEL;
@@ -209,27 +291,242 @@ fn subtract() {
 
     let big2 = big.clone();
     big += &big2;
-    let big2 = big.clone();
     big += &big2;
 
-    assert_eq!(big.count_at(TEST_VALUE_LEVEL), Ok(4));
-    assert_eq!(big.count_at(1000 * TEST_VALUE_LEVEL), Ok(4));
-    assert_eq!(big.count_at(2 * TRACKABLE_MAX), Ok(4)); // overflow smaller hist...
-    assert_eq!(big.count(), 12);
-
-    // Subtracting the smaller histogram from the bigger one should work:
-    big -= &h2;
     assert_eq!(big.count_at(TEST_VALUE_LEVEL), Ok(3));
     assert_eq!(big.count_at(1000 * TEST_VALUE_LEVEL), Ok(3));
-    assert_eq!(big.count_at(2 * TRACKABLE_MAX), Ok(4)); // overflow smaller hist...
-    assert_eq!(big.count(), 10);
+    assert_eq!(big.count_at(2 * TRACKABLE_MAX), Ok(3)); // overflow smaller hist...
+    assert_eq!(big.count(), 9);
 
-    // But trying to subtract a larger histogram into a smaller one should throw an AIOOB:
-    assert!(h1.add(&big).is_err());
+    // Subtracting the smaller histogram from the bigger one should work:
+    big -= &h1;
+    assert_eq!(big.count_at(TEST_VALUE_LEVEL), Ok(2));
+    assert_eq!(big.count_at(1000 * TEST_VALUE_LEVEL), Ok(2));
+    assert_eq!(big.count_at(2 * TRACKABLE_MAX), Ok(3)); // overflow smaller hist...
+    assert_eq!(big.count(), 7);
 
-    assert!(verify_max(h1));
-    assert!(verify_max(h2));
-    assert!(verify_max(big));
+    assert_min_max_count(h1);
+    assert_min_max_count(big);
+}
+
+#[test]
+fn subtract_values_strictly_inside_minuend_range_yields_same_min_max_no_restat() {
+  let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+
+    h1 += 1;
+    h1 += 10;
+    h1 += 100;
+    h1 += 1000;
+
+    h2 += 10;
+    h2 += 100;
+
+    // will not require a restat
+    h1.subtract(&h2).unwrap();
+
+    assert_eq!(1, h1.min());
+    assert_eq!(1000, h1.max());
+    assert_eq!(2, h1.count());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_at_extent_of_minuend_zero_count_range_recalculates_min_max() {
+    let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+
+    h1 += 1;
+    h1 += 10;
+    h1 += 100;
+    h1 += 1000;
+
+    h2 += 1;
+    h2 += 1000;
+
+    // will trigger a restat because min/max values are having counts subtracted
+    h1.subtract(&h2).unwrap();
+
+    assert_eq!(10, h1.min());
+    assert_eq!(100, h1.max());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_at_extent_of_minuend_nonzero_count_range_recalculates_same_min_max() {
+    let mut h1 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG).unwrap();
+
+    h1.record_n(1, 2).unwrap();
+    h1.record_n(10, 2).unwrap();
+    h1.record_n(100, 2).unwrap();
+    h1.record_n(1000, 2).unwrap();
+
+    h2 += 1;
+    h2 += 1000;
+
+    // will trigger a restat because min/max values are having counts subtracted
+    h1.subtract(&h2).unwrap();
+
+    assert_eq!(1, h1.min());
+    assert_eq!(1000, h1.max());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_within_bucket_precision_of_of_minuend_min_recalculates_min_max() {
+    let mut h1 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(u64::max_value(), 5).unwrap();
+
+    // sub bucket size is 2 above 2048 with 3 sigfits
+    h1.record(3000).unwrap();
+    h1.record(3100).unwrap();
+    h1.record(3200).unwrap();
+    h1.record(3300).unwrap();
+
+    // h2 has 5 sigfits, so bucket size is 1 still
+    h2 += 3001;
+
+    // will trigger a restat because min/max values are having counts subtracted
+    h1.subtract(&h2).unwrap();
+
+    assert_eq!(3100, h1.min());
+    assert_eq!(3301, h1.max());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_at_minuend_min_recalculates_min_max() {
+    let mut h1 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(u64::max_value(), 5).unwrap();
+
+    // sub bucket size is 2 above 2048 with 3 sigfits
+    h1.record(3000).unwrap();
+    h1.record(3100).unwrap();
+    h1.record(3200).unwrap();
+    h1.record(3300).unwrap();
+
+    // h2 has 5 sigfits, so bucket size is 1 still
+    h2 += 3000;
+
+    // will trigger a restat because min/max values are having counts subtracted
+    h1.subtract(&h2).unwrap();
+
+    assert_eq!(3100, h1.min());
+    assert_eq!(3301, h1.max());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_within_bucket_precision_of_of_minuend_max_recalculates_min_max() {
+    let mut h1 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(u64::max_value(), 5).unwrap();
+
+    // sub bucket size is 2 above 2048 with 3 sigfits
+    h1.record(3000).unwrap();
+    h1.record(3100).unwrap();
+    h1.record(3200).unwrap();
+    h1.record(3300).unwrap();
+
+    // h2 has 5 sigfits, so bucket size is 1 still
+    h2 += 3301;
+
+    // will trigger a restat because min/max values are having counts subtracted
+    h1.subtract(&h2).unwrap();
+
+    assert_eq!(3000, h1.min());
+    assert_eq!(3201, h1.max());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_at_minuend_max_recalculates_min_max() {
+    let mut h1 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(u64::max_value(), 5).unwrap();
+
+    // sub bucket size is 2 above 2048 with 3 sigfits
+    h1.record(3000).unwrap();
+    h1.record(3100).unwrap();
+    h1.record(3200).unwrap();
+    h1.record(3300).unwrap();
+
+    // h2 has 5 sigfits, so bucket size is 1 still
+    h2 += 3300;
+
+    // will trigger a restat because min/max values are having counts subtracted
+    h1.subtract(&h2).unwrap();
+
+    assert_eq!(3000, h1.min());
+    assert_eq!(3201, h1.max());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_minuend_saturated_total_recalculates_saturated() {
+    let mut h1 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+
+    h1.record_n(1, u64::max_value()).unwrap();
+    h1.record_n(10, u64::max_value()).unwrap();
+    h1.record_n(100, u64::max_value()).unwrap();
+    h1.record_n(1000, u64::max_value()).unwrap();
+
+    h2.record(10).unwrap();
+    h2.record(100).unwrap();
+
+    // will trigger a restat - total count is saturated
+    h1.subtract(&h2).unwrap();
+
+    // min, max haven't changed
+    assert_eq!(1, h1.min());
+    assert_eq!(1000, h1.max());
+    // still saturated
+    assert_eq!(u64::max_value(), h1.count());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
+}
+
+#[test]
+fn subtract_values_minuend_saturated_total_recalculates_not_saturated() {
+    let mut h1 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+    let mut h2 = Histogram::<u64>::new_with_max(u64::max_value(), 3).unwrap();
+
+    // 3 of these is just under u64::max_value()
+    let chunk = (u64::max_value() / 16) * 5;
+
+    h1.record_n(1, chunk).unwrap();
+    h1.record_n(10, chunk).unwrap();
+    h1.record_n(100, chunk).unwrap();
+    h1.record_n(1000, chunk).unwrap();
+
+    h2.record_n(10, chunk).unwrap();
+
+    // will trigger a restat - total count is saturated
+    h1.subtract(&h2).unwrap();
+
+    // min, max haven't changed
+    assert_eq!(1, h1.min());
+    assert_eq!(1000, h1.max());
+    // not saturated
+    assert_eq!(u64::max_value() / 16 * 15, h1.count());
+
+    assert_min_max_count(h1);
+    assert_min_max_count(h2);
 }
 
 #[test]


### PR DESCRIPTION
On master:

```
test add_precalc_random_value_1_count_different_precision_u64   ... bench:  10,614,189 ns/iter (+/- 252,423)
test add_precalc_random_value_1_count_same_dimensions_u64       ... bench:  46,938,026 ns/iter (+/- 843,737)
test add_precalc_random_value_max_count_different_precision_u64 ... bench:  10,595,457 ns/iter (+/- 214,227)
test add_precalc_random_value_max_count_same_dimensions_u64     ... bench:  46,969,248 ns/iter (+/- 670,218)
test record_correct_precalc_random_values_with_1_count_u64      ... bench:  30,194,131 ns/iter (+/- 749,564)
test record_precalc_random_values_with_1_count_u64              ... bench:   5,783,699 ns/iter (+/- 88,471)
test record_precalc_random_values_with_max_count_u64            ... bench:   5,769,106 ns/iter (+/- 162,864)
test record_random_values_with_1_count_u64                      ... bench:   7,911,239 ns/iter (+/- 185,565)
test subtract_precalc_random_value_1_count_same_dimensions_u64  ... bench:  53,987,588 ns/iter (+/- 920,352)
```

Now:

```
test add_precalc_random_value_1_count_different_precision_u64   ... bench:  10,550,182 ns/iter (+/- 456,035)
test add_precalc_random_value_1_count_same_dimensions_u64       ... bench:  46,924,786 ns/iter (+/- 1,495,721)
test add_precalc_random_value_max_count_different_precision_u64 ... bench:  10,522,688 ns/iter (+/- 322,702)
test add_precalc_random_value_max_count_same_dimensions_u64     ... bench:  46,970,544 ns/iter (+/- 1,637,041)
test record_correct_precalc_random_values_with_1_count_u64      ... bench:  26,863,186 ns/iter (+/- 408,375)
test record_precalc_random_values_with_1_count_u64              ... bench:   5,349,910 ns/iter (+/- 140,676)
test record_precalc_random_values_with_max_count_u64            ... bench:   5,350,301 ns/iter (+/- 116,121)
test record_random_values_with_1_count_u64                      ... bench:   7,252,872 ns/iter (+/- 200,447)
test subtract_precalc_random_value_1_count_same_dimensions_u64  ... bench:  62,547,610 ns/iter (+/- 1,258,993)
```

Subtraction is a little slower, recording is a little faster. I think that's probably a good tradeoff, and if anyone ever ends up caring about subtraction there's more that can be wrung out of it. Part of that is likely because subtraction wasn't handling total count overflow before, so there's now an additional case that can cause a restat. (Note: the subtraction benchmark changed in this pr, so I was careful to run master's tests with that change applied on top of master.)