### PR TITLE
Only support u8-u64 as counter types. Fixes #29.

### DIFF
--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -160,7 +160,7 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
 
                     // maintain total count so we can yield percentiles
                     // TODO overflow
-                    self.total_count_to_index = self.total_count_to_index + count.to_u64().unwrap();
+                    self.total_count_to_index = self.total_count_to_index + count.as_u64();
 
                     // make sure we don't add this index again
                     self.fresh = false;

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -589,7 +589,7 @@ fn assert_deserialized_histogram_matches_orig<T: Counter + Debug>(orig: Histogra
     // *not* saturate the total count: the deserialized one will have missed the lost increments.
     assert!(orig.total_count >= deser.total_count);
     assert_eq!(deser.total_count,
-    deser.counts.iter().fold(0_u64, |acc, &i| acc.saturating_add(i.to_u64().unwrap())));
+    deser.counts.iter().fold(0_u64, |acc, &i| acc.saturating_add(i.as_u64())));
 }
 
 /// Smallest number in our varint encoding that takes the given number of bytes

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -417,7 +417,7 @@ fn iter_all() {
 
 #[test]
 fn linear_iter_steps() {
-    let mut histogram = Histogram::<isize>::new(2).unwrap();
+    let mut histogram = Histogram::<u64>::new(2).unwrap();
     histogram += 193;
     histogram += 0;
     histogram += 1;


### PR DESCRIPTION
This will have a minor conflict with #48; I'll fix up whichever one doesn't get merged first.