### PR TITLE
Rework quantile iteration logic

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -40,7 +40,7 @@ fn main() {
                             .short("r")
                             .long("resize")
                             .help("Enable auto resize")))
-            .subcommand(SubCommand::with_name("quantiles")
+            .subcommand(SubCommand::with_name("iter-quantiles")
                     .about("Display quantiles to stdout from serialized histogram stdin")
                     .arg(Arg::with_name("ticks")
                             .short("t")
@@ -75,8 +75,8 @@ fn main() {
 
             serialize(stdin_handle, stdout_handle, h, sub_matches.is_present("compression"))
         }
-        Some("quantiles") => {
-            let sub_matches = matches.subcommand_matches("quantiles").unwrap();
+        Some("iter-quantiles") => {
+            let sub_matches = matches.subcommand_matches("iter-quantiles").unwrap();
             let ticks_per_half = sub_matches.value_of("ticks").unwrap().parse().unwrap();
             let quantile_precision = sub_matches.value_of("quantile-precision").unwrap().parse().unwrap();
             quantiles(stdin_handle, stdout_handle, quantile_precision, ticks_per_half)

--- a/src/iterators/all.rs
+++ b/src/iterators/all.rs
@@ -26,4 +26,8 @@ impl<T: Counter> PickyIterator<T> for Iter {
     fn more(&mut self, _: usize) -> bool {
         true
     }
+
+    fn quantile_iterated_to(&self) -> Option<f64> {
+        None
+    }
 }

--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -20,8 +20,8 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
         assert!(value_units_per_bucket > 0, "value_units_per_bucket must be > 0");
         HistogramIterator::new(hist,
                                Iter {
-                                   hist: hist,
-                                   value_units_per_bucket: value_units_per_bucket,
+                                   hist,
+                                   value_units_per_bucket,
                                    // won't underflow because value_units_per_bucket > 0
                                    current_step_highest_value_reporting_level: value_units_per_bucket - 1,
                                    current_step_lowest_value_reporting_level:
@@ -50,5 +50,9 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // the last value that has a count. The difference is subtle but important)...
         // TODO index + 1 could overflow 16-bit usize
         self.current_step_highest_value_reporting_level + 1 < self.hist.value_for(index + 1)
+    }
+
+    fn quantile_iterated_to(&self) -> Option<f64> {
+        None
     }
 }

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -25,8 +25,8 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
         assert!(log_base > 1.0, "log_base must be > 1.0");
         HistogramIterator::new(hist,
                                Iter {
-                                   hist: hist,
-                                   log_base: log_base,
+                                   hist,
+                                   log_base,
                                    next_value_reporting_level: value_units_in_first_bucket as f64,
                                    current_step_highest_value_reporting_level: value_units_in_first_bucket -
                                                                           1,
@@ -59,5 +59,9 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // that has a count. The difference is subtle but important)...
         self.hist.lowest_equivalent(self.next_value_reporting_level as u64) <
             self.hist.value_for(next_index)
+    }
+
+    fn quantile_iterated_to(&self) -> Option<f64> {
+        None
     }
 }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -142,7 +142,9 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
                 return None;
             }
 
-            // have we yielded all non-zeros in the histogram?
+            // TODO should check if we've reached max, not count, to avoid early termination
+            // on histograms with very large counts whose total would exceed u64::max_value()
+            // Have we yielded all non-zeros in the histogram?
             let total = self.hist.count();
             if self.prev_total_count == total {
                 // is the picker done?
@@ -163,7 +165,7 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
                     // if we've seen all counts, no other counts should be non-zero
                     if self.total_count_to_index == total {
                         // TODO this can fail when total count overflows
-                        assert!(count == T::zero());
+                        assert_eq!(count, T::zero());
                     }
 
                     // TODO overflow
@@ -182,6 +184,7 @@ impl<'a, T: 'a, P> Iterator for HistogramIterator<'a, T, P>
                 // exposed to the same value again after yielding. not sure why this is the
                 // behavior we want, but it's what the original Java implementation dictates.
 
+                // TODO count starting at 0 each time we emit a value to be less prone to overflow
                 self.prev_total_count = self.total_count_to_index;
                 return Some(val);
             }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -23,6 +23,11 @@ pub trait PickyIterator<T: Counter> {
     fn pick(&mut self, index: usize, total_count_to_index: u64) -> bool;
     /// should we keep iterating even though all future indices are zeros?
     fn more(&mut self, index: usize) -> bool;
+
+    /// Supply the quantile iterated to in the last `pick()`, if available. If `None` is returned,
+    /// the quantile of the current value will be used instead. Probably only useful for the
+    /// quantile iterator.
+    fn quantile_iterated_to(&self) -> Option<f64>;
 }
 
 /// `HistogramIterator` provides a base iterator for a `Histogram`.
@@ -53,43 +58,49 @@ pub struct HistogramIterator<'a, T: 'a + Counter, P: PickyIterator<T>> {
 pub struct IterationValue<T: Counter> {
     value: u64,
     quantile: f64,
+    quantile_iterated_to: f64,
     count_at_value: T,
     count_since_last_iteration: u64
 }
 
 impl<T: Counter> IterationValue<T> {
     /// Create a new IterationValue.
-    pub fn new(value: u64, quantile: f64, count_at_value: T, count_since_last_iteration: u64)
-            -> IterationValue<T> {
+    pub fn new(value: u64, quantile: f64, quantile_iterated_to: f64, count_at_value: T,
+               count_since_last_iteration: u64) -> IterationValue<T> {
         IterationValue {
             value,
             quantile,
+            quantile_iterated_to,
             count_at_value,
             count_since_last_iteration
         }
     }
 
-    /// the lowest value stored in the current histogram bin
+    /// The lowest value stored in the current histogram bin
     pub fn value(&self) -> u64 {
         self.value
     }
 
-    /// percent of recorded values that are equivalent to or below `value`.
+    /// Percent of recorded values that are equivalent to or below `value`.
     /// This is simply the quantile multiplied by 100.0, so if you care about maintaining the best
     /// floating-point precision, use `quantile()` instead.
     pub fn percentile(&self) -> f64 {
         self.quantile * 100.0
     }
 
-    /// quantile of recorded values that are equivalent to or below `value`
+    /// Quantile of recorded values that are equivalent to or below `value`
     pub fn quantile(&self) -> f64 { self.quantile }
 
-    /// recorded count for values equivalent to `value`
+    /// Quantile iterated to, which in the case of quantile iteration may be different from
+    /// `quantile` because slightly different quantiles can still map to the same bucket.
+    pub fn quantile_iterated_to(&self) -> f64 { self.quantile_iterated_to }
+
+    /// Recorded count for values equivalent to `value`
     pub fn count_at_value(&self) -> T {
         self.count_at_value
     }
 
-    /// number of values traversed since the last iteration step
+    /// Number of values traversed since the last iteration step
     pub fn count_since_last_iteration(&self) -> u64 {
         self.count_since_last_iteration
     }
@@ -109,9 +120,11 @@ impl<'a, T: Counter, P: PickyIterator<T>> HistogramIterator<'a, T, P> {
     }
 
     fn current(&self) -> IterationValue<T> {
+        let quantile = self.total_count_to_index as f64 / self.hist.count() as f64;
         IterationValue {
             value: self.hist.highest_equivalent(self.hist.value_for(self.current_index)),
-            quantile: self.total_count_to_index as f64 / self.hist.count() as f64,
+            quantile,
+            quantile_iterated_to: self.picker.quantile_iterated_to().unwrap_or(quantile),
             count_at_value: self.hist.count_at_index(self.current_index)
                 .expect("current index cannot exceed counts length"),
             count_since_last_iteration: self.total_count_to_index - self.prev_total_count

--- a/src/iterators/quantile.rs
+++ b/src/iterators/quantile.rs
@@ -7,8 +7,7 @@ pub struct Iter<'a, T: 'a + Counter> {
     hist: &'a Histogram<T>,
 
     ticks_per_half_distance: u32,
-    quantile_to_iterate_to: f64,
-    reached_last_recorded_value: bool,
+    quantile_to_iterate_to: f64
 }
 
 impl<'a, T: 'a + Counter> Iter<'a, T> {
@@ -21,8 +20,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
                                Iter {
                                    hist,
                                    ticks_per_half_distance,
-                                   quantile_to_iterate_to: 0.0,
-                                   reached_last_recorded_value: false,
+                                   quantile_to_iterate_to: 0.0
                                })
     }
 }
@@ -40,6 +38,13 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         let current_quantile = running_total as f64 / self.hist.count() as f64;
         if current_quantile < self.quantile_to_iterate_to {
             return false;
+        }
+
+        if self.quantile_to_iterate_to == 1.0 {
+            // We incremented to 1.0 just at the point where we finally got to the last non-zero
+            // bucket. We want to pick this value but not do the math below because it doesn't work
+            // when quantile >= 1.0.
+            return true;
         }
 
         // The choice to maintain fixed-sized "ticks" in each half-distance to 100% [starting from
@@ -61,29 +66,27 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // slice, traverse half to get to 50%. Then traverse half of the last (second) slice to get
         // to 75%, etc.
         // Minimum of 0 (1.0/1.0 = 1, log 2 of which is 0) so unsigned cast is safe.
+        // Won't hit the `inf` case because quantile < 1.0, so this should yield an actual number.
         let num_halvings = (1.0 / (1.0 - self.quantile_to_iterate_to)).log2() as u32;
         // Calculate the total number of ticks in 0-1 given that half of each slice is tick'd.
         // The number of slices is 2 ^ num_halvings, and each slice has two "half distances" to
         // tick, so we add an extra power of two to get ticks per whole distance.
         // Use u64 math so that there's less risk of overflow with large numbers of ticks and data
         // that ends up needing large numbers of halvings.
-        // TODO calculate the worst case total_ticks and make sure we can't ever overflow here
         let total_ticks = (self.ticks_per_half_distance as u64)
             .checked_mul(1_u64.checked_shl(num_halvings + 1).expect("too many halvings"))
             .expect("too many total ticks");
         let increment_size = 1.0 / total_ticks as f64;
-        self.quantile_to_iterate_to += increment_size;
+        // Unclear if it's possible for adding a very small increment to 0.999999... to yield > 1.0
+        // but let's just be safe since FP is weird and this code is not likely to be very hot.
+        self.quantile_to_iterate_to = 1.0_f64.min(self.quantile_to_iterate_to + increment_size);
         true
     }
 
     fn more(&mut self, _: usize) -> bool {
-        // We want one additional last step to 100%
-        if !self.reached_last_recorded_value && self.hist.count() != 0 {
-            self.quantile_to_iterate_to = 1.0;
-            self.reached_last_recorded_value = true;
-            true
-        } else {
-            false
-        }
+        // No need to go past the point where cumulative count == total count, because that's
+        // quantile 1.0 and will be reported as such in the IterationValue, even if
+        // `quantile_to_iterate_to` is somewhere below 1.0 -- we still got to the final bucket.
+        false
     }
 }

--- a/src/iterators/recorded.rs
+++ b/src/iterators/recorded.rs
@@ -37,4 +37,8 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
     fn more(&mut self, _: usize) -> bool {
         false
     }
+
+    fn quantile_iterated_to(&self) -> Option<f64> {
+        None
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@ extern crate num_traits as num;
 
 use std::borrow::Borrow;
 use std::cmp;
+use std::fmt;
 use std::ops::{AddAssign, SubAssign};
 use num::ToPrimitive;
 
@@ -218,7 +219,7 @@ const ORIGINAL_MAX: u64 = 0;
 /// Partial ordering is used for threshholding, also usually in the context of quantiles.
 pub trait Counter
     : num::Num + num::ToPrimitive + num::FromPrimitive + num::Saturating + num::CheckedSub
-    + num::CheckedAdd + Copy + PartialOrd<Self> {
+    + num::CheckedAdd + Copy + PartialOrd<Self> + fmt::Debug {
 
     /// Counter as a f64.
     fn as_f64(&self) -> f64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1002,17 +1002,17 @@ impl<T: Counter> Histogram<T> {
     ///
     /// println!("{:?}", hist.iter_quantiles(1).collect::<Vec<_>>());
     ///
-    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.0001), 0.0001, 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.0001), 0.0001, 0.0, 1, 1)));
     /// // step size = 50
-    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.5), 0.5, 1, 5000 - 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.5), 0.5, 0.5, 1, 5000 - 1)));
     /// // step size = 25
-    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.75), 0.75, 1, 2500)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.75), 0.75, 0.75, 1, 2500)));
     /// // step size = 12.5
-    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.875), 0.875, 1, 1250)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.875), 0.875, 0.875, 1, 1250)));
     /// // step size = 6.25
-    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.9375), 0.9375, 1, 625)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.9375), 0.9375, 0.9375, 1, 625)));
     /// // step size = 3.125
-    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.9688), 0.9688, 1, 313)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(hist.value_at_quantile(0.9688), 0.9688, 0.96875, 1, 313)));
     /// // etc...
     /// ```
     pub fn iter_quantiles<'a>(&'a self, ticks_per_half_distance: u32)
@@ -1038,15 +1038,15 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_linear(100);
-    /// assert_eq!(perc.next(), Some(IterationValue::new(99, hist.quantile_below(99), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(199, hist.quantile_below(199), 0, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(299, hist.quantile_below(299), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(399, hist.quantile_below(399), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(499, hist.quantile_below(499), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(599, hist.quantile_below(599), 0, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(699, hist.quantile_below(699), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(799, hist.quantile_below(799), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(899, hist.quantile_below(899), 0, 2)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(99, hist.quantile_below(99), hist.quantile_below(99), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(199, hist.quantile_below(199), hist.quantile_below(199), 0, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(299, hist.quantile_below(299), hist.quantile_below(299), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(399, hist.quantile_below(399), hist.quantile_below(399), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(499, hist.quantile_below(499), hist.quantile_below(499), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(599, hist.quantile_below(599), hist.quantile_below(599), 0, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(699, hist.quantile_below(699), hist.quantile_below(699), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(799, hist.quantile_below(799), hist.quantile_below(799), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(899, hist.quantile_below(899), hist.quantile_below(899), 0, 2)));
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_linear<'a>(&'a self, step: u64)
@@ -1070,10 +1070,10 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_log(1, 10.0);
-    /// assert_eq!(perc.next(), Some(IterationValue::new(0, hist.quantile_below(0), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(9, hist.quantile_below(9), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(99, hist.quantile_below(99), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(999, hist.quantile_below(999), 0, 4)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(0, hist.quantile_below(0), hist.quantile_below(0), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(9, hist.quantile_below(9), hist.quantile_below(9), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(99, hist.quantile_below(99), hist.quantile_below(99), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(999, hist.quantile_below(999), hist.quantile_below(999), 0, 4)));
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_log<'a>(&'a self, start: u64, exp: f64)
@@ -1097,10 +1097,10 @@ impl<T: Counter> Histogram<T> {
     /// hist += 850;
     ///
     /// let mut perc = hist.iter_recorded();
-    /// assert_eq!(perc.next(), Some(IterationValue::new(100, hist.quantile_below(100), 1, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(500, hist.quantile_below(500), 1, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(800, hist.quantile_below(800), 1, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(850, hist.quantile_below(850), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(100, hist.quantile_below(100), hist.quantile_below(100), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(500, hist.quantile_below(500), hist.quantile_below(500), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(800, hist.quantile_below(800), hist.quantile_below(800), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(850, hist.quantile_below(850), hist.quantile_below(850), 1, 1)));
     /// assert_eq!(perc.next(), None);
     /// ```
     pub fn iter_recorded<'a>(&'a self)
@@ -1124,17 +1124,17 @@ impl<T: Counter> Histogram<T> {
     /// hist += 8;
     ///
     /// let mut perc = hist.iter_all();
-    /// assert_eq!(perc.next(), Some(IterationValue::new(0, 0.0, 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(1, hist.quantile_below(1), 1, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(2, hist.quantile_below(2), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(3, hist.quantile_below(3), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(4, hist.quantile_below(4), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(5, hist.quantile_below(5), 1, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(6, hist.quantile_below(6), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(7, hist.quantile_below(7), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(8, hist.quantile_below(8), 1, 1)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(9, hist.quantile_below(9), 0, 0)));
-    /// assert_eq!(perc.next(), Some(IterationValue::new(10, 1.0, 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(0, 0.0, 0.0, 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(1, hist.quantile_below(1), hist.quantile_below(1), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(2, hist.quantile_below(2), hist.quantile_below(2), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(3, hist.quantile_below(3), hist.quantile_below(3), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(4, hist.quantile_below(4), hist.quantile_below(4), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(5, hist.quantile_below(5), hist.quantile_below(5), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(6, hist.quantile_below(6), hist.quantile_below(6), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(7, hist.quantile_below(7), hist.quantile_below(7), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(8, hist.quantile_below(8), hist.quantile_below(8), 1, 1)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(9, hist.quantile_below(9), hist.quantile_below(9), 0, 0)));
+    /// assert_eq!(perc.next(), Some(IterationValue::new(10, 1.0, 1.0, 0, 0)));
     /// ```
     pub fn iter_all<'a>(&'a self) -> HistogramIterator<'a, T, iterators::all::Iter> {
         iterators::all::Iter::new(self)


### PR DESCRIPTION
See #66.

I've gotta run at the moment but I wanted to get this in front of people. I don't think the quantile iterator needs a nontrivial `more()`; I'm guessing that was an expedient tweak at some point in the Java impl's past but I don't think it really makes mathematical sense.

Also, in `(1.0 / (1.0 - self.quantile_to_iterate_to)).log2() as u32`, the floating point calculations were yielding `inf` at quantile 1.0, which became `0` as a `u32`. So, now we short circuit before that logic.