### PR TITLE
Rework iteration to avoid overflow

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -125,7 +125,7 @@ fn quantiles<R: BufRead, W: Write>(mut reader: R, mut writer: W, quantile_precis
             writer.write_all(
                 format!(
                     "{:12} {:1.*} {:1.*} {:10} {:14.2}\n",
-                    v.value(),
+                    v.value_iterated_to(),
                     quantile_precision,
                     v.quantile(),
                     quantile_precision,
@@ -138,7 +138,7 @@ fn quantiles<R: BufRead, W: Write>(mut reader: R, mut writer: W, quantile_precis
             writer.write_all(
                 format!(
                     "{:12} {:1.*} {:1.*} {:10} {:>14}\n",
-                    v.value(),
+                    v.value_iterated_to(),
                     quantile_precision,
                     v.quantile(),
                     quantile_precision,

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -121,7 +121,7 @@ fn quantiles<R: BufRead, W: Write>(mut reader: R, mut writer: W, quantile_precis
     let mut sum = 0;
     for v in hist.iter_quantiles(ticks_per_half) {
         sum += v.count_since_last_iteration();
-        if v.quantile() < 1.0 {
+        if v.quantile_iterated_to() < 1.0 {
             writer.write_all(
                 format!(
                     "{:12} {:1.*} {:1.*} {:10} {:14.2}\n",
@@ -131,7 +131,7 @@ fn quantiles<R: BufRead, W: Write>(mut reader: R, mut writer: W, quantile_precis
                     quantile_precision,
                     v.quantile_iterated_to(),
                     sum,
-                    1_f64 / (1_f64 - v.quantile())
+                    1_f64 / (1_f64 - v.quantile_iterated_to())
                 ).as_ref(),
             )?;
         } else {

--- a/src/iterators/all.rs
+++ b/src/iterators/all.rs
@@ -13,7 +13,7 @@ impl Iter {
 }
 
 impl<T: Counter> PickyIterator<T> for Iter {
-    fn pick(&mut self, index: usize, _: u64) -> Option<PickMetadata> {
+    fn pick(&mut self, index: usize, _: u64, _: T) -> Option<PickMetadata> {
         if self.visited.map(|i| i != index).unwrap_or(true) {
             // haven't visited this index yet
             self.visited = Some(index);

--- a/src/iterators/all.rs
+++ b/src/iterators/all.rs
@@ -1,14 +1,16 @@
 use Counter;
 use Histogram;
-use iterators::{HistogramIterator, PickyIterator, PickMetadata};
+use iterators::{HistogramIterator, PickMetadata, PickyIterator};
 
 /// An iterator that will yield every bin.
-pub struct Iter { visited: Option<usize> }
+pub struct Iter {
+    visited: Option<usize>,
+}
 
 impl Iter {
     /// Construct a new full iterator. See `Histogram::iter_all` for details.
     pub fn new<'a, T: Counter>(hist: &'a Histogram<T>) -> HistogramIterator<'a, T, Iter> {
-        HistogramIterator::new(hist, Iter{ visited: None })
+        HistogramIterator::new(hist, Iter { visited: None })
     }
 }
 

--- a/src/iterators/all.rs
+++ b/src/iterators/all.rs
@@ -1,6 +1,6 @@
 use Counter;
 use Histogram;
-use iterators::{HistogramIterator, PickyIterator};
+use iterators::{HistogramIterator, PickyIterator, PickMetadata};
 
 /// An iterator that will yield every bin.
 pub struct Iter { visited: Option<usize> }
@@ -13,21 +13,17 @@ impl Iter {
 }
 
 impl<T: Counter> PickyIterator<T> for Iter {
-    fn pick(&mut self, index: usize, _: u64) -> bool {
+    fn pick(&mut self, index: usize, _: u64) -> Option<PickMetadata> {
         if self.visited.map(|i| i != index).unwrap_or(true) {
             // haven't visited this index yet
             self.visited = Some(index);
-            true
+            Some(PickMetadata::new(None, None))
         } else {
-            false
+            None
         }
     }
 
     fn more(&mut self, _: usize) -> bool {
         true
-    }
-
-    fn quantile_iterated_to(&self) -> Option<f64> {
-        None
     }
 }

--- a/src/iterators/linear.rs
+++ b/src/iterators/linear.rs
@@ -31,7 +31,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, _: u64) -> Option<PickMetadata> {
+    fn pick(&mut self, index: usize, _: u64, _: T) -> Option<PickMetadata> {
         let val = self.hist.value_for(index);
         if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last_index() {
             let metadata = PickMetadata::new(None, Some(self.current_step_highest_value_reporting_level));

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -37,7 +37,7 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, _: u64) -> Option<PickMetadata> {
+    fn pick(&mut self, index: usize, _: u64, _: T) -> Option<PickMetadata> {
         let val = self.hist.value_for(index);
         if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last_index() {
             let metadata = PickMetadata::new(None, Some(self.current_step_highest_value_reporting_level));
@@ -46,7 +46,7 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
             // won't underflow since next_value_reporting_level starts > 0 and only grows
             self.current_step_highest_value_reporting_level = self.next_value_reporting_level as u64 - 1;
             self.current_step_lowest_value_reporting_level = self.hist
-            .lowest_equivalent(self.current_step_highest_value_reporting_level);
+                    .lowest_equivalent(self.current_step_highest_value_reporting_level);
             Some(metadata)
         } else {
             None

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -1,6 +1,6 @@
 use Counter;
 use Histogram;
-use iterators::{HistogramIterator, PickyIterator};
+use iterators::{HistogramIterator, PickyIterator, PickMetadata};
 
 /// An iterator that will yield at log-size steps through the histogram's value range.
 pub struct Iter<'a, T: 'a + Counter> {
@@ -37,31 +37,28 @@ impl<'a, T: 'a + Counter> Iter<'a, T> {
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, _: u64) -> bool {
+    fn pick(&mut self, index: usize, _: u64) -> Option<PickMetadata> {
         let val = self.hist.value_for(index);
         if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last_index() {
+            let metadata = PickMetadata::new(None, Some(self.current_step_highest_value_reporting_level));
             // implies log_base must be > 1.0
             self.next_value_reporting_level *= self.log_base;
             // won't underflow since next_value_reporting_level starts > 0 and only grows
             self.current_step_highest_value_reporting_level = self.next_value_reporting_level as u64 - 1;
             self.current_step_lowest_value_reporting_level = self.hist
-                .lowest_equivalent(self.current_step_highest_value_reporting_level);
-            true
+            .lowest_equivalent(self.current_step_highest_value_reporting_level);
+            Some(metadata)
         } else {
-            false
+            None
         }
     }
 
-    fn more(&mut self, next_index: usize) -> bool {
+    fn more(&mut self, index_to_pick: usize) -> bool {
         // If the next iterate will not move to the next sub bucket index (which is empty if if we
         // reached this point), then we are not yet done iterating (we want to iterate until we are
         // no longer on a value that has a count, rather than util we first reach the last value
         // that has a count. The difference is subtle but important)...
         self.hist.lowest_equivalent(self.next_value_reporting_level as u64) <
-            self.hist.value_for(next_index)
-    }
-
-    fn quantile_iterated_to(&self) -> Option<f64> {
-        None
+            self.hist.value_for(index_to_pick)
     }
 }

--- a/src/iterators/log.rs
+++ b/src/iterators/log.rs
@@ -1,6 +1,6 @@
 use Counter;
 use Histogram;
-use iterators::{HistogramIterator, PickyIterator, PickMetadata};
+use iterators::{HistogramIterator, PickMetadata, PickyIterator};
 
 /// An iterator that will yield at log-size steps through the histogram's value range.
 pub struct Iter<'a, T: 'a + Counter> {
@@ -17,36 +17,45 @@ pub struct Iter<'a, T: 'a + Counter> {
 
 impl<'a, T: 'a + Counter> Iter<'a, T> {
     /// Construct a new logarithmic iterator. See `Histogram::iter_log` for details.
-    pub fn new(hist: &'a Histogram<T>,
-               value_units_in_first_bucket: u64,
-               log_base: f64)
-               -> HistogramIterator<'a, T, Iter<'a, T>> {
-        assert!(value_units_in_first_bucket > 0, "value_units_per_bucket must be > 0");
+    pub fn new(
+        hist: &'a Histogram<T>,
+        value_units_in_first_bucket: u64,
+        log_base: f64,
+    ) -> HistogramIterator<'a, T, Iter<'a, T>> {
+        assert!(
+            value_units_in_first_bucket > 0,
+            "value_units_per_bucket must be > 0"
+        );
         assert!(log_base > 1.0, "log_base must be > 1.0");
-        HistogramIterator::new(hist,
-                               Iter {
-                                   hist,
-                                   log_base,
-                                   next_value_reporting_level: value_units_in_first_bucket as f64,
-                                   current_step_highest_value_reporting_level: value_units_in_first_bucket -
-                                                                          1,
-                                   current_step_lowest_value_reporting_level:
-                                       hist.lowest_equivalent(value_units_in_first_bucket - 1),
-                               })
+        HistogramIterator::new(
+            hist,
+            Iter {
+                hist,
+                log_base,
+                next_value_reporting_level: value_units_in_first_bucket as f64,
+                current_step_highest_value_reporting_level: value_units_in_first_bucket - 1,
+                current_step_lowest_value_reporting_level: hist.lowest_equivalent(
+                    value_units_in_first_bucket - 1,
+                ),
+            },
+        )
     }
 }
 
 impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
     fn pick(&mut self, index: usize, _: u64, _: T) -> Option<PickMetadata> {
         let val = self.hist.value_for(index);
-        if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last_index() {
-            let metadata = PickMetadata::new(None, Some(self.current_step_highest_value_reporting_level));
+        if val >= self.current_step_lowest_value_reporting_level || index == self.hist.last_index()
+        {
+            let metadata =
+                PickMetadata::new(None, Some(self.current_step_highest_value_reporting_level));
             // implies log_base must be > 1.0
             self.next_value_reporting_level *= self.log_base;
             // won't underflow since next_value_reporting_level starts > 0 and only grows
-            self.current_step_highest_value_reporting_level = self.next_value_reporting_level as u64 - 1;
+            self.current_step_highest_value_reporting_level =
+                self.next_value_reporting_level as u64 - 1;
             self.current_step_lowest_value_reporting_level = self.hist
-                    .lowest_equivalent(self.current_step_highest_value_reporting_level);
+                .lowest_equivalent(self.current_step_highest_value_reporting_level);
             Some(metadata)
         } else {
             None
@@ -58,7 +67,8 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
         // reached this point), then we are not yet done iterating (we want to iterate until we are
         // no longer on a value that has a count, rather than util we first reach the last value
         // that has a count. The difference is subtle but important)...
-        self.hist.lowest_equivalent(self.next_value_reporting_level as u64) <
-            self.hist.value_for(index_to_pick)
+        self.hist
+            .lowest_equivalent(self.next_value_reporting_level as u64)
+            < self.hist.value_for(index_to_pick)
     }
 }

--- a/src/iterators/quantile.rs
+++ b/src/iterators/quantile.rs
@@ -43,6 +43,7 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
             // We incremented to 1.0 just at the point where we finally got to the last non-zero
             // bucket. We want to pick this value but not do the math below because it doesn't work
             // when quantile >= 1.0.
+            // TODO we should be picking here, once
             return None;
         }
 
@@ -84,6 +85,7 @@ impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
     }
 
     fn more(&mut self, _: usize) -> bool {
+        // TODO this should probably be more like the Java impl
         // No need to go past the point where cumulative count == total count, because that's
         // quantile 1.0 and will be reported as such in the IterationValue, even if
         // `quantile_to_iterate_to` is somewhere below 1.0 -- we still got to the final bucket.

--- a/src/iterators/recorded.rs
+++ b/src/iterators/recorded.rs
@@ -1,6 +1,6 @@
 use Counter;
 use Histogram;
-use iterators::{HistogramIterator, PickyIterator, PickMetadata};
+use iterators::{HistogramIterator, PickMetadata, PickyIterator};
 
 /// An iterator that will yield only bins with at least one sample.
 pub struct Iter {
@@ -10,10 +10,7 @@ pub struct Iter {
 impl Iter {
     /// Construct a new sampled iterator. See `Histogram::iter_recorded` for details.
     pub fn new<T: Counter>(hist: &Histogram<T>) -> HistogramIterator<T, Iter> {
-        HistogramIterator::new(hist,
-                               Iter {
-                                   visited: None,
-                               })
+        HistogramIterator::new(hist, Iter { visited: None })
     }
 }
 

--- a/src/iterators/recorded.rs
+++ b/src/iterators/recorded.rs
@@ -3,28 +3,23 @@ use Histogram;
 use iterators::{HistogramIterator, PickyIterator, PickMetadata};
 
 /// An iterator that will yield only bins with at least one sample.
-pub struct Iter<'a, T: 'a + Counter> {
-    hist: &'a Histogram<T>,
+pub struct Iter {
     visited: Option<usize>,
 }
 
-impl<'a, T: 'a + Counter> Iter<'a, T> {
+impl Iter {
     /// Construct a new sampled iterator. See `Histogram::iter_recorded` for details.
-    pub fn new(hist: &'a Histogram<T>) -> HistogramIterator<'a, T, Iter<'a, T>> {
+    pub fn new<T: Counter>(hist: &Histogram<T>) -> HistogramIterator<T, Iter> {
         HistogramIterator::new(hist,
                                Iter {
-                                   hist,
                                    visited: None,
                                })
     }
 }
 
-impl<'a, T: 'a + Counter> PickyIterator<T> for Iter<'a, T> {
-    fn pick(&mut self, index: usize, _: u64) -> Option<PickMetadata> {
-        // is the count non-zero?
-        let count = self.hist.count_at_index(index)
-            .expect("index must be valid by PickyIterator contract");
-        if count != T::zero() {
+impl<T: Counter> PickyIterator<T> for Iter {
+    fn pick(&mut self, index: usize, _: u64, count_at_index: T) -> Option<PickMetadata> {
+        if count_at_index != T::zero() {
             // have we visited before?
             if self.visited.map(|i| i != index).unwrap_or(true) {
                 self.visited = Some(index);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! // ...
 //! for v in hist.iter_recorded() {
 //!     println!("{}'th percentile of data is {} with {} samples",
-//!         v.percentile(), v.value(), v.count_at_value());
+//!         v.percentile(), v.value_iterated_to(), v.count_at_value());
 //! }
 //! ```
 //!
@@ -514,7 +514,7 @@ impl<T: Counter> Histogram<T> {
     pub fn clone_correct(&self, interval: u64) -> Histogram<T> {
         let mut h = Histogram::new_from(self);
         for v in self.iter_recorded() {
-            h.record_n_correct(v.value(), v.count_at_value(), interval)
+            h.record_n_correct(v.value_iterated_to(), v.count_at_value(), interval)
                 .expect("Same dimensions; all values should be representable");
         }
         h
@@ -642,7 +642,7 @@ impl<T: Counter> Histogram<T> {
         let source = source.borrow();
 
         for v in source.iter_recorded() {
-            self.record_n_correct(v.value(), v.count_at_value(), interval)?;
+            self.record_n_correct(v.value_iterated_to(), v.count_at_value(), interval)?;
         }
         Ok(())
     }
@@ -1191,7 +1191,7 @@ impl<T: Counter> Histogram<T> {
         self.iter_recorded().fold(0.0_f64, |total, v| {
             // TODO overflow?
             total +
-                self.median_equivalent(v.value()) as f64 * v.count_at_value().as_f64()
+                self.median_equivalent(v.value_iterated_to()) as f64 * v.count_at_value().as_f64()
                     / self.total_count as f64
         })
     }
@@ -1204,7 +1204,7 @@ impl<T: Counter> Histogram<T> {
 
         let mean = self.mean();
         let geom_dev_tot = self.iter_recorded().fold(0.0_f64, |gdt, v| {
-            let dev = self.median_equivalent(v.value()) as f64 - mean;
+            let dev = self.median_equivalent(v.value_iterated_to()) as f64 - mean;
             gdt + (dev * dev) * v.count_since_last_iteration() as f64
         });
 

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -295,7 +295,7 @@ fn count_at_beyond_max_value() {
 fn quantile_iter() {
     let Loaded { hist, .. } = load_histograms();
     for v in hist.iter_quantiles(5 /* ticks per half */) {
-        assert_eq!(v.value(), hist.highest_equivalent(hist.value_at_quantile(v.quantile())));
+        assert_eq!(v.value_iterated_to(), hist.highest_equivalent(hist.value_at_quantile(v.quantile())));
     }
 }
 
@@ -457,7 +457,7 @@ fn iter_all() {
     for (i, v) in raw.iter_all().enumerate() {
         if i == 1000 {
             assert_eq!(v.count_since_last_iteration(), 10000);
-        } else if hist.equivalent(v.value(), 100000000) {
+        } else if hist.equivalent(v.value_iterated_to(), 100000000) {
             assert_eq!(v.count_since_last_iteration(), 1);
         } else {
             assert_eq!(v.count_since_last_iteration(), 0);
@@ -509,7 +509,7 @@ fn value_duplication() {
     let mut counts = Vec::with_capacity(histogram1.len());
     for v in histogram1.iter_all() {
         if v.count_since_last_iteration() > 0 {
-            ranges.push(v.value());
+            ranges.push(v.value_iterated_to());
             counts.push(v.count_since_last_iteration());
         }
         num += 1;

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -1,17 +1,10 @@
 //! Tests from HistogramDataAccessTest.java
 
 extern crate hdrsample;
-extern crate rand;
 extern crate ieee754;
 extern crate rug;
 
-use hdrsample::{Histogram, Counter};
-
-use rand::Rng;
-use rand::distributions::range::Range;
-use rand::distributions::IndependentSample;
-use ieee754::Ieee754;
-use rug::{Rational, Integer};
+use hdrsample::Histogram;
 
 macro_rules! assert_near {
     ($a: expr, $b: expr, $tolerance: expr) => {{
@@ -52,15 +45,15 @@ fn load_histograms() -> Loaded {
     // 100 times per second (10,000 results), followed by a 100 second pause with a single (100
     // second) recorded result. Recording is done indicating an expected EINTERVAL between samples
     // of 10 msec:
-    for _ in 0..10000 {
-        let v = 1000; // 1ms
+    for _ in 0..10_000 {
+        let v = 1_000; // 1ms
         hist.record_correct(v, EINTERVAL).unwrap();
         scaled_hist.record_correct(v * SCALEF, EINTERVAL * SCALEF).unwrap();
         raw += v;
         scaled_raw += v * SCALEF;
     }
 
-    let v = 100000000;
+    let v = 100_000_000;
     hist.record_correct(v, EINTERVAL).unwrap();
     scaled_hist.record_correct(v * SCALEF, EINTERVAL * SCALEF).unwrap();
     raw += v;
@@ -307,8 +300,8 @@ fn quantile_iter() {
 }
 
 #[test]
-fn linear_iter() {
-    let Loaded { hist, raw, .. } = load_histograms();
+fn linear_iter_raw() {
+    let Loaded { raw, .. } = load_histograms();
 
     // Note that using linear buckets should work "as expected" as long as the number of linear
     // buckets is lower than the resolution level determined by
@@ -318,10 +311,10 @@ fn linear_iter() {
 
     // Iterate raw data using linear buckets of 100 msec each.
     let mut num = 0;
-    for (i, v) in raw.iter_linear(100000).enumerate() {
+    for (i, v) in raw.iter_linear(100_000).enumerate() {
         match i {
             // Raw Linear 100 msec bucket # 0 added a count of 10000
-            0 => assert_eq!(v.count_since_last_iteration(), 10000),
+            0 => assert_eq!(v.count_since_last_iteration(), 10_000),
             // Raw Linear 100 msec bucket # 999 added a count of 1
             999 => assert_eq!(v.count_since_last_iteration(), 1),
             // Remaining raw Linear 100 msec buckets add a count of 0
@@ -329,14 +322,19 @@ fn linear_iter() {
         }
         num += 1;
     }
-    assert_eq!(num, 1000);
+    assert_eq!(num, 1_000);
+}
 
-    num = 0;
+#[test]
+fn linear_iter_corrected() {
+    let Loaded { hist, .. } = load_histograms();
+
+    let mut num = 0;
     let mut total_added_counts = 0;
     // Iterate data using linear buckets of 10 msec each.
-    for (i, v) in hist.iter_linear(10000).enumerate() {
+    for (i, v) in hist.iter_linear(10_000).enumerate() {
         if i == 0 {
-            assert_eq!(v.count_since_last_iteration(), 10000);
+            assert_eq!(v.count_since_last_iteration(), 10_000);
         }
 
         // Because value resolution is low enough (3 digits) that multiple linear buckets will end
@@ -348,15 +346,15 @@ fn linear_iter() {
         num += 1;
     }
     // There should be 10000 linear buckets of size 10000 usec between 0 and 100 sec.
-    assert_eq!(num, 10000);
-    assert_eq!(total_added_counts, 20000);
+    assert_eq!(num, 10_000);
+    assert_eq!(total_added_counts, 20_000);
 
     num = 0;
     total_added_counts = 0;
     // Iterate data using linear buckets of 1 msec each.
-    for (i, v) in hist.iter_linear(1000).enumerate() {
+    for (i, v) in hist.iter_linear(1_000).enumerate() {
         if i == 1 {
-            assert_eq!(v.count_since_last_iteration(), 10000);
+            assert_eq!(v.count_since_last_iteration(), 10_000);
         }
 
         // Because value resolution is low enough (3 digits) that multiple linear buckets will end
@@ -377,8 +375,8 @@ fn linear_iter() {
     // out of the last populated bucket, there is not way to tell if the iteration should stop at
     // 100000 or 100007 steps. The proper thing to do is to run to the end of the sub-bucket
     // quanta...
-    assert_eq!(num, 100007);
-    assert_eq!(total_added_counts, 20000);
+    assert_eq!(num, 100_007);
+    assert_eq!(total_added_counts, 20_000);
 }
 
 #[test]
@@ -439,7 +437,7 @@ fn iter_recorded() {
         }
 
         // The count in a recorded iterator value should never be zero
-        assert!(v.count_at_value() != 0);
+        assert_ne!(v.count_at_value(), 0);
         // The count in a recorded iterator value should exactly match the amount added since the
         // last iteration
         assert_eq!(v.count_at_value(), v.count_since_last_iteration());
@@ -523,8 +521,7 @@ fn value_duplication() {
         histogram2.record_n(ranges[i], counts[i]).unwrap();
     }
 
-    assert!(histogram1 == histogram2,
-            "histograms should be equal after re-recording");
+    assert_eq!(histogram1, histogram2, "histograms should be equal after re-recording");
 }
 
 #[test]
@@ -541,366 +538,4 @@ fn total_count_exceeds_bucket_type() {
     }
 
     assert_eq!(400, h.count());
-}
-
-#[test]
-fn value_at_quantile_internal_count_exceeds_bucket_type() {
-    let mut h: Histogram<u8> = Histogram::new(3).unwrap();
-
-    for _ in 0..200 {
-        h.record(100).unwrap();
-    }
-
-
-    for _ in 0..200 {
-        h.record(100_000).unwrap();
-    }
-
-    // we won't get back the original input because of bucketing
-    assert_eq!(h.highest_equivalent(100_000), h.value_at_quantile(1.0));
-}
-
-
-#[test]
-fn value_at_quantile_2_values() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-
-    h.record(1).unwrap();
-    h.record(2).unwrap();
-
-    assert_eq!(1, h.value_at_quantile(0.25));
-    assert_eq!(1, h.value_at_quantile(0.5));
-
-    let almost_half = 0.5000000000000001;
-    let next = 0.5000000000000002;
-    // one ulp apart
-    assert_eq!(almost_half, 0.5_f64.next());
-    assert_eq!(next, almost_half.next());
-
-    assert_eq!(2, h.value_at_quantile(almost_half));
-    assert_eq!(2, h.value_at_quantile(next));
-}
-
-#[test]
-fn value_at_quantile_5_values() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-
-    h.record(1).unwrap();
-    h.record(2).unwrap();
-    h.record(2).unwrap();
-    h.record(2).unwrap();
-    h.record(2).unwrap();
-
-    assert_eq!(2, h.value_at_quantile(0.25));
-    assert_eq!(2, h.value_at_quantile(0.3));
-}
-
-#[test]
-fn value_at_quantile_20k() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-
-    for i in 1..20_001 {
-        h.record(i).unwrap();
-    }
-
-    assert_eq!(20_000, h.count());
-
-    assert!(h.equivalent(19961, h.value_at_quantile(0.99805)));
-}
-
-#[test]
-fn value_at_quantile_large_numbers() {
-    let mut h = Histogram::<u64>::new_with_bounds(20_000_000, 100_000_000, 5).unwrap();
-    h.record(100_000_000).unwrap();
-    h.record(20_000_000).unwrap();
-    h.record(30_000_000).unwrap();
-
-    assert!(h.equivalent(20_000_000, h.value_at_quantile(0.5)));
-    assert!(h.equivalent(30_000_000, h.value_at_quantile(0.5)));
-    assert!(h.equivalent(100_000_000, h.value_at_quantile(0.8333)));
-    assert!(h.equivalent(100_000_000, h.value_at_quantile(0.8334)));
-    assert!(h.equivalent(100_000_000, h.value_at_quantile(0.99)));
-}
-
-#[test]
-fn value_at_quantile_matches_quantile_iter_sequence_values() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-
-    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
-    let mut errors: u64 = 0;
-
-    for length in lengths {
-        h.reset();
-
-        for i in 1..(length + 1) {
-            h.record(i).unwrap();
-        }
-
-        assert_eq!(length, h.count());
-
-        let iter = h.iter_quantiles(100);
-
-        for iter_val in iter {
-            let calculated_value = h.value_at_quantile(iter_val.quantile());
-            let v = iter_val.value();
-
-            // Quantile iteration has problematic floating-point calculations. Calculating the
-            // quantile involves something like `index / total_count`, and that's then multiplied
-            // by `total_count` again to get the value at the quantile. This tends to produce
-            // artifacts, so this test will frequently fail if you expect the actual value to
-            // match the calculated value. Instead, we allow it to be one bucket high or low.
-
-            if calculated_value != v
-                && calculated_value != prev_value_nonzero_count(&h, v)
-                && calculated_value != next_value_nonzero_count(&h, v) {
-                let q_count_rational = calculate_quantile_count(iter_val.quantile(), length);
-
-                println!("len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
-                         length, iter_val.quantile(), iter_val.quantile() * length as f64,
-                         q_count_rational, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
-                errors += 1;
-            }
-        }
-    }
-
-    assert_eq!(0, errors);
-}
-
-#[test]
-fn value_at_quantile_matches_quantile_iter_random_values() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-
-    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
-
-    let mut rng = rand::thread_rng();
-    let mut errors: u64 = 0;
-
-    for length in lengths {
-        h.reset();
-
-        for v in RandomMaxIter::new(&mut rng).take(length) {
-            h.record(v).unwrap();
-        }
-
-        assert_eq!(length as u64, h.count());
-
-        let iter = h.iter_quantiles(100);
-
-        for iter_val in iter {
-            let calculated_value = h.value_at_quantile(iter_val.quantile());
-            let v = iter_val.value();
-
-            // Quantile iteration has problematic floating-point calculations. Calculating the
-            // quantile involves something like `index / total_count`, and that's then multiplied
-            // by `total_count` again to get the value at the quantile. This tends to produce
-            // artifacts, so this test will frequently fail if you expect the actual value to
-            // match the calculated value. Instead, we allow it to be one bucket high or low.
-
-            if calculated_value != v
-                && calculated_value != prev_value_nonzero_count(&h, v)
-                && calculated_value != next_value_nonzero_count(&h, v) {
-                let q_count_rational = calculate_quantile_count(iter_val.quantile(), length as u64);
-
-                println!("len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
-                         length, iter_val.quantile(), iter_val.quantile() * length as f64,
-                         q_count_rational, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
-                errors += 1;
-            }
-        }
-    }
-
-    assert_eq!(0, errors);
-}
-
-#[test]
-fn value_at_quantile_matches_quantile_at_each_value_sequence_values() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-
-    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
-    let mut errors: u64 = 0;
-
-    for length in lengths {
-        h.reset();
-
-        for i in 1..(length + 1) {
-            h.record(i).unwrap();
-        }
-
-        assert_eq!(length, h.count());
-
-        for v in 1..(length + 1) {
-            let quantile = (Rational::from(Integer::from(v as u64))
-                / Rational::from(Integer::from(length as u64))).to_f64();
-            let calculated_value = h.value_at_quantile(quantile);
-            if !h.equivalent(v, calculated_value) {
-                println!("len {} value {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
-                         length, v, quantile, quantile * length as f64,
-                         v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
-                errors += 1;
-            }
-        }
-    }
-
-    assert_eq!(0, errors);
-}
-
-#[test]
-fn value_at_quantile_matches_quantile_at_each_value_random_values() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-    let mut values = Vec::new();
-
-    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
-
-    let mut rng = rand::thread_rng();
-
-    let mut errors: u64 = 0;
-
-    for length in lengths {
-        h.reset();
-        values.clear();
-
-        for v in RandomMaxIter::new(&mut rng).take(length) {
-            h.record(v).unwrap();
-            values.push(v);
-        }
-
-        values.sort();
-
-        assert_eq!(length as u64, h.count());
-
-        for (index, &v) in values.iter().enumerate() {
-            let quantile = (Rational::from(Integer::from(index as u64 + 1))
-                / Rational::from(Integer::from(length as u64))).to_f64();
-            let calculated_value = h.value_at_quantile(quantile);
-            if !h.equivalent(v, calculated_value) {
-                errors += 1;
-                println!("len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
-                         length, index, quantile, quantile * length as f64, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
-            }
-        }
-    }
-
-    assert_eq!(0, errors);
-}
-
-#[test]
-fn value_at_quantile_matches_random_quantile_random_values() {
-    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-    let mut values = Vec::new();
-
-    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
-
-    let mut rng = rand::thread_rng();
-    let quantile_range = Range::new(0_f64, 1_f64.next());
-
-    let mut errors: u64 = 0;
-
-    for length in lengths {
-        h.reset();
-        values.clear();
-
-        for v in RandomMaxIter::new(&mut rng).take(length) {
-            h.record(v).unwrap();
-            values.push(v);
-        }
-
-        values.sort();
-
-        assert_eq!(length as u64, h.count());
-
-        for _ in 0..1_000 {
-            let quantile = quantile_range.ind_sample(&mut rng);
-            let index_at_quantile = (Rational::from_f64(quantile).unwrap()
-                * Rational::from(Integer::from(length as u64)))
-                .to_integer().to_u64().unwrap() as usize;
-            let calculated_value = h.value_at_quantile(quantile);
-            let v = values[index_at_quantile];
-            if !h.equivalent(v, calculated_value) {
-                errors += 1;
-                println!("len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
-                         length, index_at_quantile, quantile, quantile * length as f64, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
-            }
-        }
-    }
-
-    assert_eq!(0, errors);
-}
-
-/// An iterator of random `u64`s where the maximum value for each random number generation is picked
-/// from a uniform distribution of the 64 possible bit lengths for a `u64`.
-///
-/// This helps create somewhat more realistic distributions of numbers. A simple random u64 is very
-/// likely to be a HUGE number; this helps scatter some numbers down in the smaller end.
-struct RandomMaxIter<'a, R: Rng + 'a> {
-    rng: &'a mut R
-}
-
-impl<'a, R: Rng + 'a> RandomMaxIter<'a, R> {
-    fn new(rng: &'a mut R) -> RandomMaxIter<R> {
-        RandomMaxIter {
-            rng
-        }
-    }
-}
-
-impl<'a, R: Rng + 'a> Iterator for RandomMaxIter<'a, R> {
-    type Item = u64;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let bit_length = self.rng.gen_range(0, 65);
-
-        return Some(match bit_length {
-            0 => 0,
-            64 => u64::max_value(),
-            x => self.rng.gen_range(0, 1 << x)
-        });
-    }
-}
-
-/// Calculate the count at a quantile with arbitrary precision arithmetic
-fn calculate_quantile_count(quantile: f64, count: u64) -> u64 {
-    let product = Rational::from_f64(quantile).unwrap() * Rational::from(Integer::from(count));
-    let prod_as_int = (product).to_integer();
-
-    // emulate ceil()
-    if product == Rational::from(prod_as_int.clone()) {
-        return prod_as_int.to_u64().unwrap();
-    } else {
-        // to_integer()'s rounding down has chopped off a fractional part
-        return prod_as_int.to_u64().unwrap() + 1;
-    }
-}
-
-fn next_value_nonzero_count<C: Counter>(h: &Histogram<C>, start_value: u64) -> u64 {
-    let mut v = h.next_non_equivalent(start_value);
-
-    loop {
-        if h.count_at(v) > C::zero() {
-            return h.highest_equivalent(v);
-        }
-
-        v = h.next_non_equivalent(v);
-    }
-}
-
-
-fn prev_value_nonzero_count<C: Counter>(h: &Histogram<C>, start_value: u64) -> u64 {
-    let mut v = h.lowest_equivalent(start_value).saturating_sub(1);
-
-    loop {
-        if v == 0 {
-            return 0;
-        }
-
-        if h.count_at(v) > C::zero() {
-            return h.highest_equivalent(v);
-        }
-
-        v = h.lowest_equivalent(v).saturating_sub(1);
-    }
 }

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -25,7 +25,7 @@ macro_rules! assert_near {
 fn verify_max<T: hdrsample::Counter, B: Borrow<Histogram<T>>>(hist: B) -> bool {
     let hist = hist.borrow();
     if let Some(mx) = hist.iter_recorded()
-        .map(|v| v.value())
+        .map(|v| v.value_iterated_to())
         .map(|v| hist.highest_equivalent(v))
         .last() {
         hist.max() == mx
@@ -246,7 +246,7 @@ fn are_equal<T, B1, B2>(actual: B1, expected: B2)
     let actual = actual.borrow();
     let expected = expected.borrow();
 
-    assert!(actual == expected);
+    assert_eq!(actual, expected);
     assert_eq!(actual.count_at(TEST_VALUE_LEVEL),
                expected.count_at(TEST_VALUE_LEVEL));
     assert_eq!(actual.count_at(10 * TEST_VALUE_LEVEL),

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -1,0 +1,33 @@
+extern crate hdrsample;
+extern crate num;
+extern crate rand;
+
+use hdrsample::Histogram;
+
+#[test]
+fn iter_recorded_non_saturated_total_count() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    h.record(1).unwrap();
+    h.record(1_000).unwrap();
+    h.record(1_000_000).unwrap();
+
+    let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
+    assert_eq!(expected, h.iter_recorded()
+        .map(|iv| iv.value())
+        .collect::<Vec<u64>>());
+}
+
+#[test]
+fn iter_recorded_saturated_total_count() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    h.record_n(1, u64::max_value()).unwrap();
+    h.record_n(1_000, u64::max_value()).unwrap();
+    h.record_n(1_000_000, u64::max_value()).unwrap();
+
+    let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
+    assert_eq!(expected, h.iter_recorded()
+        .map(|iv| iv.value())
+        .collect::<Vec<u64>>());
+}

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -1,6 +1,4 @@
 extern crate hdrsample;
-extern crate num;
-extern crate rand;
 
 use hdrsample::Histogram;
 

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -12,8 +12,8 @@ fn iter_recorded_non_saturated_total_count() {
 
     let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
     assert_eq!(expected, h.iter_recorded()
-        .map(|iv| iv.value_iterated_to())
-        .collect::<Vec<u64>>());
+            .map(|iv| iv.value_iterated_to())
+            .collect::<Vec<u64>>());
 }
 
 #[test]
@@ -26,8 +26,8 @@ fn iter_recorded_saturated_total_count() {
 
     let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
     assert_eq!(expected, h.iter_recorded()
-        .map(|iv| iv.value_iterated_to())
-        .collect::<Vec<u64>>());
+            .map(|iv| iv.value_iterated_to())
+            .collect::<Vec<u64>>());
 }
 
 #[test]
@@ -143,4 +143,373 @@ fn iter_linear_visits_buckets_once_when_step_size_equals_bucket_size() {
     assert_eq!((4103, 1), iter_values[1025]);
 
     assert_eq!(1026, iter_values.len());
+}
+
+#[test]
+fn iter_all_values_all_buckets() {
+    let mut h = histo64(1, 8191, 3);
+
+    h.record(1).unwrap();
+    h.record(2).unwrap();
+    // first in top half
+    h.record(1024).unwrap();
+    // first in 2nd bucket
+    h.record(2048).unwrap();
+    // first in 3rd
+    h.record(4096).unwrap();
+    // smallest value in last sub bucket of third
+    h.record(8192 - 4).unwrap();
+
+    let iter_values: Vec<(u64, u64)> = h.iter_all()
+            .map(|v| (v.value_iterated_to(), v.count_at_value()))
+            .collect();
+
+    // 4096 distinct expressible values
+    assert_eq!(2048 + 2 * 1024, iter_values.len());
+
+    // value to expected count
+    let expected = vec![
+        (1, 1),
+        (2, 1),
+        (1024, 1),
+        (2048 + 1, 1),
+        (4096 + 3, 1),
+        (8192 - 1, 1)];
+
+    let nonzero_count = iter_values.iter()
+            .filter(|v| v.1 != 0)
+            .map(|&v| v)
+            .collect::<Vec<(u64, u64)>>();
+
+    assert_eq!(expected, nonzero_count);
+}
+
+#[test]
+fn iter_all_values_all_buckets_unit_magnitude_2() {
+    let mut h = histo64(4, 16384 - 1, 3);
+
+    h.record(4).unwrap();
+    // first in top half
+    h.record(4096).unwrap();
+    // first in second bucket
+    h.record(8192).unwrap();
+    // smallest value in last sub bucket of second
+    h.record(16384 - 8).unwrap();
+
+    let iter_values: Vec<(u64, u64)> = h.iter_all()
+            .map(|v| (v.value_iterated_to(), v.count_at_value()))
+            .collect();
+
+    // magnitude 2 means 2nd bucket is scale of 8 = 2 * 2^2
+    assert_eq!(2048 + 1024, iter_values.len());
+
+    // value to expected count
+    let expected = vec![
+        (4 + 3, 1),
+        (4096 + 3, 1),
+        (8192 + 7, 1),
+        (16384 - 1, 1)];
+
+    let nonzero_count = iter_values.iter()
+            .filter(|v| v.1 != 0)
+            .map(|&v| v)
+            .collect::<Vec<(u64, u64)>>();
+
+    assert_eq!(expected, nonzero_count);
+}
+
+
+#[test]
+fn iter_recorded_values_all_buckets() {
+    let mut h = histo64(1, 8191, 3);
+
+    h.record(1).unwrap();
+    h.record(2).unwrap();
+    // first in top half
+    h.record(1024).unwrap();
+    // first in 2nd bucket
+    h.record(2048).unwrap();
+    // first in 3rd
+    h.record(4096).unwrap();
+    // smallest value in last sub bucket of third
+    h.record(8192 - 4).unwrap();
+
+    let iter_values: Vec<(u64, u64)> = h.iter_recorded()
+            .map(|v| (v.value_iterated_to(), v.count_at_value()))
+            .collect();
+
+    let expected = vec![
+        (1, 1),
+        (2, 1),
+        (1024, 1),
+        (2048 + 1, 1),
+        (4096 + 3, 1),
+        (8192 - 1, 1)];
+
+    let nonzero_count = iter_values.iter()
+            .filter(|v| v.1 != 0)
+            .map(|&v| v)
+            .collect::<Vec<(u64, u64)>>();
+
+    assert_eq!(expected, nonzero_count);
+}
+
+#[test]
+fn iter_recorded_values_all_buckets_unit_magnitude_2() {
+    let mut h = histo64(4, 16384 - 1, 3);
+
+    h.record(4).unwrap();
+    // first in top half
+    h.record(4096).unwrap();
+    // first in second bucket
+    h.record(8192).unwrap();
+    // smallest value in last sub bucket of second
+    h.record(16384 - 8).unwrap();
+
+    let iter_values: Vec<(u64, u64)> = h.iter_recorded()
+            .map(|v| (v.value_iterated_to(), v.count_at_value()))
+            .collect();
+
+    let expected = vec![
+        (4 + 3, 1),
+        (4096 + 3, 1),
+        (8192 + 7, 1),
+        (16384 - 1, 1)];
+
+    let nonzero_count = iter_values.iter()
+            .filter(|v| v.1 != 0)
+            .map(|&v| v)
+            .collect::<Vec<(u64, u64)>>();
+
+    assert_eq!(expected, nonzero_count);
+}
+
+#[test]
+fn iter_logarithmic_bucket_values_min_1_base_2_all_buckets() {
+    let h = prepare_histo_for_logarithmic_iterator();
+
+    let iter_values: Vec<(u64, u64, u64)> = h.iter_log(1, 2.0)
+            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
+            .collect();
+
+    let expected = vec![
+        (0, 0, 0),
+        (1, 1, 1),
+        (3, 1, 0),
+        (7, 0, 0),
+        (15, 0, 0),
+        (31, 3, 1),
+        (63, 0, 0),
+        (127, 0, 0),
+        (255, 0, 0),
+        (511, 0, 0),
+        (1023, 0, 0),
+        (2047, 3, 0),
+        (4095, 1, 1)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_logarithmic_bucket_values_min_4_base_2_all_buckets() {
+    let h = prepare_histo_for_logarithmic_iterator();
+
+    let iter_values: Vec<(u64, u64, u64)> = h.iter_log(4, 2.0)
+            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
+            .collect();
+
+    let expected = vec![
+        (3, 2, 0),
+        (7, 0, 0),
+        (15, 0, 0),
+        (31, 3, 1),
+        (63, 0, 0),
+        (127, 0, 0),
+        (255, 0, 0),
+        (511, 0, 0),
+        (1023, 0, 0),
+        (2047, 3, 0),
+        (4095, 1, 1)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_logarithmic_bucket_values_min_1_base_2_all_buckets_unit_magnitude_2() {
+    // two buckets
+    let mut h = histo64(4, 16383, 3);
+
+    h.record(3).unwrap();
+    h.record(4).unwrap();
+
+    // inside [2^(4 + 2), 2^(5 + 2)
+    h.record(70).unwrap();
+    h.record(80).unwrap();
+    h.record(90).unwrap();
+
+    // in 2nd half
+    h.record(5000).unwrap();
+    h.record(5100).unwrap();
+    h.record(5200).unwrap();
+
+    // in last sub bucket of 2nd bucket
+    h.record(16384 - 1).unwrap();
+
+    let iter_values: Vec<(u64, u64, u64)> = h.iter_log(1, 2.0)
+            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
+            .collect();
+
+    // first 3 iterations are just getting up to 3, which is still the '0' sub bucket.
+    // All at the same index, so count_at_value stays at 1 for the first 3
+    let expected = vec![
+        (0, 1, 1),
+        (1, 0, 1),
+        (3, 0, 1),
+        (7, 1, 1),
+        (15, 0, 0),
+        (31, 0, 0),
+        (63, 0, 0),
+        (127, 3, 0),
+        (255, 0, 0),
+        (511, 0, 0),
+        (1023, 0, 0),
+        (2047, 0, 0),
+        (4095, 0, 0),
+        (8191, 3, 0),
+        (16383, 1, 1)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_logarithmic_bucket_values_min_1_base_10_all_buckets() {
+    let h = prepare_histo_for_logarithmic_iterator();
+
+    let iter_values: Vec<(u64, u64, u64)> = h.iter_log(1, 10.0)
+            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
+            .collect();
+
+    let expected = vec![
+        (0, 0, 0),
+        (9, 2, 0),
+        (99, 3, 0),
+        (999, 0, 0),
+        (9999, 4, 1)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_linear_bucket_values_size_8_all_buckets() {
+    // two buckets: 32 sub-buckets with scale 1, 16 with scale 2
+    let mut h = histo64(1, 63, 1);
+
+    assert_eq!(48, h.len());
+
+    h.record(3).unwrap();
+    h.record(4).unwrap();
+    h.record(7).unwrap();
+
+    // top half of first bucket
+    h.record(24).unwrap();
+    h.record(25).unwrap();
+
+    h.record(61).unwrap();
+    // stored in same sub bucket as last value
+    h.record(62).unwrap();
+    // in last sub bucket of 2nd bucket
+    h.record(63).unwrap();
+
+    let iter_values: Vec<(u64, u64, u64)> = h.iter_linear(8)
+            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
+            .collect();
+
+    let expected = vec![
+        (7, 3, 1),
+        (15, 0, 0),
+        (23, 0, 0),
+        (31, 2, 0),
+        (39, 0, 0),
+        (47, 0, 0),
+        (55, 0, 0),
+        (63, 3, 2)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_quantiles_smorgasboard() {
+    let mut h = histo64(1, 4095, 3);
+
+    // one of each value up to 2 buckets
+    for i in 0..4096 {
+        h.record(i).unwrap();
+    }
+
+    let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
+            .map(|v| (v.value_iterated_to(),
+                      v.count_since_last_iteration(),
+                      v.count_at_value(),
+                      v.quantile(),
+                      v.quantile_iterated_to()))
+            .collect();
+
+    // penultimate percentile is 100.0 because 99.96% of 4095 is 4093.36, so it falls into last
+    // sub bucket, thus gets to 100.0% of count.
+    // this does look like it takes 2 steps and then decreases the step size
+    let expected = vec![
+        (0, 1, 1, 0.000244140625, 0.0),
+        (1023, 1023, 1, 0.25, 0.25),
+        (2047, 1024, 1, 0.5, 0.5),
+        (2559, 512, 2, 0.625, 0.625),
+        (3071, 512, 2, 0.75, 0.75),
+        (3327, 256, 2, 0.8125, 0.8125),
+        (3583, 256, 2, 0.875, 0.875),
+        (3711, 128, 2, 0.90625, 0.90625),
+        (3839, 128, 2, 0.9375, 0.9375),
+        (3903, 64, 2, 0.953125, 0.953125),
+        (3967, 64, 2, 0.96875, 0.96875),
+        (3999, 32, 2, 0.9765625, 0.9765625),
+        (4031, 32, 2, 0.984375, 0.984375),
+        (4047, 16, 2, 0.98828125, 0.98828125),
+        (4063, 16, 2, 0.9921875, 0.9921875),
+        (4071, 8, 2, 0.994140625, 0.994140625),
+        (4079, 8, 2, 0.99609375, 0.99609375),
+        (4083, 4, 2, 0.9970703125, 0.9970703125),
+        (4087, 4, 2, 0.998046875, 0.998046875),
+        (4089, 2, 2, 0.99853515625, 0.99853515625),
+        (4091, 2, 2, 0.9990234375, 0.9990234375),
+        (4093, 2, 2, 0.99951171875, 0.999267578125),
+        (4093, 0, 2, 0.99951171875, 0.99951171875),
+        (4095, 2, 2, 1.0, 0.9996337890625),
+        (4095, 0, 2, 1.0, 1.0)];
+
+    assert_eq!(expected, iter_values);
+}
+
+fn prepare_histo_for_logarithmic_iterator() -> Histogram<u64> {
+    // two buckets
+    let mut h = histo64(1, 4095, 3);
+
+    h.record(1).unwrap();
+    h.record(2).unwrap();
+
+    // inside [2^4, 2^5)
+    h.record(20).unwrap();
+    h.record(25).unwrap();
+    h.record(31).unwrap();
+
+    // in 2nd half
+    h.record(1500).unwrap();
+    h.record(1600).unwrap();
+    h.record(1700).unwrap();
+
+    // in last sub bucket of 2nd bucket
+    h.record(4096 - 1).unwrap();
+
+    h
+}
+
+fn histo64(lowest_discernible_value: u64, highest_trackable_value: u64, num_significant_digits: u8) -> Histogram<u64> {
+    Histogram::<u64>::new_with_bounds(lowest_discernible_value, highest_trackable_value, num_significant_digits).unwrap()
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -11,9 +11,12 @@ fn iter_recorded_non_saturated_total_count() {
     h.record(1_000_000).unwrap();
 
     let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
-    assert_eq!(expected, h.iter_recorded()
+    assert_eq!(
+        expected,
+        h.iter_recorded()
             .map(|iv| iv.value_iterated_to())
-            .collect::<Vec<u64>>());
+            .collect::<Vec<u64>>()
+    );
 }
 
 #[test]
@@ -25,9 +28,12 @@ fn iter_recorded_saturated_total_count() {
     h.record_n(1_000_000, u64::max_value()).unwrap();
 
     let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
-    assert_eq!(expected, h.iter_recorded()
+    assert_eq!(
+        expected,
+        h.iter_recorded()
             .map(|iv| iv.value_iterated_to())
-            .collect::<Vec<u64>>());
+            .collect::<Vec<u64>>()
+    );
 }
 
 #[test]
@@ -53,12 +59,18 @@ fn iter_linear_count_since_last_iteration_saturates() {
         // 8-9 has nothing
         (9, 0),
         // 10-11 has just 10's count
-        (11, 400)];
+        (11, 400),
+    ];
 
     // step in 2s to test count accumulation for each step
-    assert_eq!(expected, h.iter_linear(2)
-            .map(|iv| (iv.value_iterated_to(), iv.count_since_last_iteration()))
-            .collect::<Vec<(u64, u64)>>());
+    assert_eq!(
+        expected,
+        h.iter_linear(2)
+            .map(|iv| {
+                (iv.value_iterated_to(), iv.count_since_last_iteration())
+            })
+            .collect::<Vec<(u64, u64)>>()
+    );
 }
 
 #[test]
@@ -80,8 +92,10 @@ fn iter_linear_visits_buckets_wider_than_step_size_multiple_times() {
     h.record(4100).unwrap();
 
     let iter_values = h.iter_linear(1)
-            .map(|iv| (iv.value_iterated_to(), iv.count_since_last_iteration()))
-            .collect::<Vec<(u64, u64)>>();
+        .map(|iv| {
+            (iv.value_iterated_to(), iv.count_since_last_iteration())
+        })
+        .collect::<Vec<(u64, u64)>>();
 
     // bucket size 1
     assert_eq!((0, 0), iter_values[0]);
@@ -128,8 +142,10 @@ fn iter_linear_visits_buckets_once_when_step_size_equals_bucket_size() {
     h.record(4100).unwrap();
 
     let iter_values = h.iter_linear(4)
-            .map(|iv| (iv.value_iterated_to(), iv.count_since_last_iteration()))
-            .collect::<Vec<(u64, u64)>>();
+        .map(|iv| {
+            (iv.value_iterated_to(), iv.count_since_last_iteration())
+        })
+        .collect::<Vec<(u64, u64)>>();
 
     // bucket size 1
     assert_eq!((3, 1), iter_values[0]);
@@ -161,8 +177,8 @@ fn iter_all_values_all_buckets() {
     h.record(8192 - 4).unwrap();
 
     let iter_values: Vec<(u64, u64)> = h.iter_all()
-            .map(|v| (v.value_iterated_to(), v.count_at_value()))
-            .collect();
+        .map(|v| (v.value_iterated_to(), v.count_at_value()))
+        .collect();
 
     // 4096 distinct expressible values
     assert_eq!(2048 + 2 * 1024, iter_values.len());
@@ -174,12 +190,14 @@ fn iter_all_values_all_buckets() {
         (1024, 1),
         (2048 + 1, 1),
         (4096 + 3, 1),
-        (8192 - 1, 1)];
+        (8192 - 1, 1),
+    ];
 
-    let nonzero_count = iter_values.iter()
-            .filter(|v| v.1 != 0)
-            .map(|&v| v)
-            .collect::<Vec<(u64, u64)>>();
+    let nonzero_count = iter_values
+        .iter()
+        .filter(|v| v.1 != 0)
+        .map(|&v| v)
+        .collect::<Vec<(u64, u64)>>();
 
     assert_eq!(expected, nonzero_count);
 }
@@ -197,23 +215,20 @@ fn iter_all_values_all_buckets_unit_magnitude_2() {
     h.record(16384 - 8).unwrap();
 
     let iter_values: Vec<(u64, u64)> = h.iter_all()
-            .map(|v| (v.value_iterated_to(), v.count_at_value()))
-            .collect();
+        .map(|v| (v.value_iterated_to(), v.count_at_value()))
+        .collect();
 
     // magnitude 2 means 2nd bucket is scale of 8 = 2 * 2^2
     assert_eq!(2048 + 1024, iter_values.len());
 
     // value to expected count
-    let expected = vec![
-        (4 + 3, 1),
-        (4096 + 3, 1),
-        (8192 + 7, 1),
-        (16384 - 1, 1)];
+    let expected = vec![(4 + 3, 1), (4096 + 3, 1), (8192 + 7, 1), (16384 - 1, 1)];
 
-    let nonzero_count = iter_values.iter()
-            .filter(|v| v.1 != 0)
-            .map(|&v| v)
-            .collect::<Vec<(u64, u64)>>();
+    let nonzero_count = iter_values
+        .iter()
+        .filter(|v| v.1 != 0)
+        .map(|&v| v)
+        .collect::<Vec<(u64, u64)>>();
 
     assert_eq!(expected, nonzero_count);
 }
@@ -235,8 +250,8 @@ fn iter_recorded_values_all_buckets() {
     h.record(8192 - 4).unwrap();
 
     let iter_values: Vec<(u64, u64)> = h.iter_recorded()
-            .map(|v| (v.value_iterated_to(), v.count_at_value()))
-            .collect();
+        .map(|v| (v.value_iterated_to(), v.count_at_value()))
+        .collect();
 
     let expected = vec![
         (1, 1),
@@ -244,7 +259,8 @@ fn iter_recorded_values_all_buckets() {
         (1024, 1),
         (2048 + 1, 1),
         (4096 + 3, 1),
-        (8192 - 1, 1)];
+        (8192 - 1, 1),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -262,14 +278,10 @@ fn iter_recorded_values_all_buckets_unit_magnitude_2() {
     h.record(16384 - 8).unwrap();
 
     let iter_values: Vec<(u64, u64)> = h.iter_recorded()
-            .map(|v| (v.value_iterated_to(), v.count_at_value()))
-            .collect();
+        .map(|v| (v.value_iterated_to(), v.count_at_value()))
+        .collect();
 
-    let expected = vec![
-        (4 + 3, 1),
-        (4096 + 3, 1),
-        (8192 + 7, 1),
-        (16384 - 1, 1)];
+    let expected = vec![(4 + 3, 1), (4096 + 3, 1), (8192 + 7, 1), (16384 - 1, 1)];
 
     assert_eq!(expected, iter_values);
 }
@@ -279,8 +291,14 @@ fn iter_logarithmic_bucket_values_min_1_base_2_all_buckets() {
     let h = prepare_histo_for_logarithmic_iterator();
 
     let iter_values: Vec<(u64, u64, u64)> = h.iter_log(1, 2.0)
-            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+            )
+        })
+        .collect();
 
     let expected = vec![
         (0, 0, 0),
@@ -295,7 +313,8 @@ fn iter_logarithmic_bucket_values_min_1_base_2_all_buckets() {
         (511, 0, 0),
         (1023, 0, 0),
         (2047, 3, 0),
-        (4095, 1, 1)];
+        (4095, 1, 1),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -305,8 +324,14 @@ fn iter_logarithmic_bucket_values_min_4_base_2_all_buckets() {
     let h = prepare_histo_for_logarithmic_iterator();
 
     let iter_values: Vec<(u64, u64, u64)> = h.iter_log(4, 2.0)
-            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+            )
+        })
+        .collect();
 
     let expected = vec![
         (3, 2, 0),
@@ -319,7 +344,8 @@ fn iter_logarithmic_bucket_values_min_4_base_2_all_buckets() {
         (511, 0, 0),
         (1023, 0, 0),
         (2047, 3, 0),
-        (4095, 1, 1)];
+        (4095, 1, 1),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -346,8 +372,14 @@ fn iter_logarithmic_bucket_values_min_1_base_2_all_buckets_unit_magnitude_2() {
     h.record(16384 - 1).unwrap();
 
     let iter_values: Vec<(u64, u64, u64)> = h.iter_log(1, 2.0)
-            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+            )
+        })
+        .collect();
 
     // first 3 iterations are just getting up to 3, which is still the '0' sub bucket.
     // All at the same index, so count_at_value stays at 1 for the first 3
@@ -366,7 +398,8 @@ fn iter_logarithmic_bucket_values_min_1_base_2_all_buckets_unit_magnitude_2() {
         (2047, 0, 0),
         (4095, 0, 0),
         (8191, 3, 0),
-        (16383, 1, 1)];
+        (16383, 1, 1),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -376,15 +409,16 @@ fn iter_logarithmic_bucket_values_min_1_base_10_all_buckets() {
     let h = prepare_histo_for_logarithmic_iterator();
 
     let iter_values: Vec<(u64, u64, u64)> = h.iter_log(1, 10.0)
-            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+            )
+        })
+        .collect();
 
-    let expected = vec![
-        (0, 0, 0),
-        (9, 2, 0),
-        (99, 3, 0),
-        (999, 0, 0),
-        (9999, 4, 1)];
+    let expected = vec![(0, 0, 0), (9, 2, 0), (99, 3, 0), (999, 0, 0), (9999, 4, 1)];
 
     assert_eq!(expected, iter_values);
 }
@@ -411,8 +445,14 @@ fn iter_linear_bucket_values_size_8_all_buckets() {
     h.record(63).unwrap();
 
     let iter_values: Vec<(u64, u64, u64)> = h.iter_linear(8)
-            .map(|v| (v.value_iterated_to(), v.count_since_last_iteration(), v.count_at_value()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+            )
+        })
+        .collect();
 
     let expected = vec![
         (7, 3, 1),
@@ -422,7 +462,8 @@ fn iter_linear_bucket_values_size_8_all_buckets() {
         (39, 0, 0),
         (47, 0, 0),
         (55, 0, 0),
-        (63, 3, 2)];
+        (63, 3, 2),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -437,12 +478,16 @@ fn iter_quantiles_smorgasboard() {
     }
 
     let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
-            .map(|v| (v.value_iterated_to(),
-                      v.count_since_last_iteration(),
-                      v.count_at_value(),
-                      v.quantile(),
-                      v.quantile_iterated_to()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+                v.quantile(),
+                v.quantile_iterated_to(),
+            )
+        })
+        .collect();
 
     // penultimate percentile is 100.0 because 99.96% of 4095 is 4093.36, so it falls into last
     // sub bucket, thus gets to 100.0% of count.
@@ -472,7 +517,8 @@ fn iter_quantiles_smorgasboard() {
         (4093, 2, 2, 0.99951171875, 0.999267578125),
         (4093, 0, 2, 0.99951171875, 0.99951171875),
         (4095, 2, 2, 1.0, 0.9996337890625),
-        (4095, 0, 2, 1.0, 1.0)];
+        (4095, 0, 2, 1.0, 1.0),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -485,19 +531,24 @@ fn iter_quantiles_iterates_to_end_skips_intermediate_at_final_value() {
     h.record_n(1_000, 1_000_000).unwrap();
 
     let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
-            .map(|v| (v.value_iterated_to(),
-                      v.count_since_last_iteration(),
-                      v.count_at_value(),
-                      v.quantile(),
-                      v.quantile_iterated_to()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+                v.quantile(),
+                v.quantile_iterated_to(),
+            )
+        })
+        .collect();
 
     // almost every nonzero quantile is in the bucket whose value is at quantile 1.0, so we should
     // iterate into that bucket (at quantile iteration 0.25), then skip to quantile iteration 1.0
     let expected = vec![
         (1, 1, 1, 0.000000999999000001, 0.0),
         (1000, 1000_000, 1000_000, 1.0, 0.25),
-        (1000, 0, 1000_000, 1.0, 1.0)];
+        (1000, 0, 1000_000, 1.0, 1.0),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -509,130 +560,136 @@ fn iter_quantiles_saturated_count_before_max_value() {
     for i in 0..1000 {
         // this will quickly saturate total count as well as count since last iteration
         h.record_n(i, u64::max_value() / 100).unwrap();
-    };
+    }
 
     let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
-            .map(|v| (v.value_iterated_to(),
-                      v.count_since_last_iteration(),
-                      v.count_at_value(),
-                      v.quantile(),
-                      v.quantile_iterated_to()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+                v.quantile(),
+                v.quantile_iterated_to(),
+            )
+        })
+        .collect();
 
     // here we do NOT skip to 1.0 because we haven't detected that we're at the max value (because
     // we aren't!).
     // This will iterate towards quantile 1.0  and will reach a point where a fraction very close to
     // 1.0 + a tiny tiny increment = the same fraction. It should then skip to 1.0.
-    let expected = vec![(0, 184467440737095516, 184467440737095516, 0.01, 0.0),
-                        (24, 4427218577690292384, 184467440737095516, 0.25, 0.25),
-                        (49, 4611686018427387900, 184467440737095516, 0.5, 0.5),
-                        (62, 2398076729582241708, 184467440737095516, 0.63, 0.625),
-                        (74, 2213609288845146192, 184467440737095516, 0.75, 0.75),
-                        (81, 1291272085159668612, 184467440737095516, 0.82, 0.8125),
-                        (87, 1106804644422573096, 184467440737095516, 0.88, 0.875),
-                        (90, 553402322211286548, 184467440737095516, 0.91, 0.90625),
-                        (93, 553402322211286548, 184467440737095516, 0.94, 0.9375),
-                        (95, 368934881474191032, 184467440737095516, 0.96, 0.953125),
-                        (96, 184467440737095516, 184467440737095516, 0.97, 0.96875),
-                        (97, 184467440737095516, 184467440737095516, 0.98, 0.9765625),
-                        (98, 184467440737095516, 184467440737095516, 0.99, 0.984375),
-                        (98, 0, 184467440737095516, 0.99, 0.98828125),
-                        (99, 184467440737095516, 184467440737095516, 1.0, 0.9921875),
-                        (99, 0, 184467440737095516, 1.0, 0.994140625),
-                        (99, 0, 184467440737095516, 1.0, 0.99609375),
-                        (99, 0, 184467440737095516, 1.0, 0.9970703125),
-                        (99, 0, 184467440737095516, 1.0, 0.998046875),
-                        (99, 0, 184467440737095516, 1.0, 0.99853515625),
-                        (99, 0, 184467440737095516, 1.0, 0.9990234375),
-                        (99, 0, 184467440737095516, 1.0, 0.999267578125),
-                        (99, 0, 184467440737095516, 1.0, 0.99951171875),
-                        (99, 0, 184467440737095516, 1.0, 0.9996337890625),
-                        (99, 0, 184467440737095516, 1.0, 0.999755859375),
-                        (99, 0, 184467440737095516, 1.0, 0.99981689453125),
-                        (99, 0, 184467440737095516, 1.0, 0.9998779296875),
-                        (99, 0, 184467440737095516, 1.0, 0.999908447265625),
-                        (99, 0, 184467440737095516, 1.0, 0.99993896484375),
-                        (99, 0, 184467440737095516, 1.0, 0.9999542236328125),
-                        (99, 0, 184467440737095516, 1.0, 0.999969482421875),
-                        (99, 0, 184467440737095516, 1.0, 0.9999771118164063),
-                        (99, 0, 184467440737095516, 1.0, 0.9999847412109375),
-                        (99, 0, 184467440737095516, 1.0, 0.9999885559082031),
-                        (99, 0, 184467440737095516, 1.0, 0.9999923706054688),
-                        (99, 0, 184467440737095516, 1.0, 0.9999942779541016),
-                        (99, 0, 184467440737095516, 1.0, 0.9999961853027344),
-                        (99, 0, 184467440737095516, 1.0, 0.9999971389770508),
-                        (99, 0, 184467440737095516, 1.0, 0.9999980926513672),
-                        (99, 0, 184467440737095516, 1.0, 0.9999985694885254),
-                        (99, 0, 184467440737095516, 1.0, 0.9999990463256836),
-                        (99, 0, 184467440737095516, 1.0, 0.9999992847442627),
-                        (99, 0, 184467440737095516, 1.0, 0.9999995231628418),
-                        (99, 0, 184467440737095516, 1.0, 0.9999996423721313),
-                        (99, 0, 184467440737095516, 1.0, 0.9999997615814209),
-                        (99, 0, 184467440737095516, 1.0, 0.9999998211860657),
-                        (99, 0, 184467440737095516, 1.0, 0.9999998807907104),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999105930328),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999403953552),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999552965164),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999701976776),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999776482582),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999850988388),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999888241291),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999925494194),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999944120646),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999962747097),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999972060323),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999981373549),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999986030161),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999990686774),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999993015081),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999995343387),
-                        (99, 0, 184467440737095516, 1.0, 0.999999999650754),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999997671694),
-                        (99, 0, 184467440737095516, 1.0, 0.999999999825377),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999998835847),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999126885),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999417923),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999563443),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999708962),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999781721),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999854481),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999890861),
-                        (99, 0, 184467440737095516, 1.0, 0.999999999992724),
-                        (99, 0, 184467440737095516, 1.0, 0.999999999994543),
-                        (99, 0, 184467440737095516, 1.0, 0.999999999996362),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999972715),
-                        (99, 0, 184467440737095516, 1.0, 0.999999999998181),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999986358),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999990905),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999993179),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999995453),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999996589),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999997726),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999998295),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999998863),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999147),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999432),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999574),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999716),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999787),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999858),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999893),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999929),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999947),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999964),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999973),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999982),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999987),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999991),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999993),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999996),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999997),
-                        (99, 0, 184467440737095516, 1.0, 0.9999999999999998),
-                        // at 0.99...98, adding the resulting increment = the same 0.999...9998.
-                        // The increment calculations at this point involve 1 / (1 << 54), and f64
-                        // has 53 significand bits, so it's not too surprising that this is where
-                        // things get noticeably imprecise.
-                        (99, 0, 184467440737095516, 1.0, 1.0)];
+    let expected = vec![
+        (0, 184467440737095516, 184467440737095516, 0.01, 0.0),
+        (24, 4427218577690292384, 184467440737095516, 0.25, 0.25),
+        (49, 4611686018427387900, 184467440737095516, 0.5, 0.5),
+        (62, 2398076729582241708, 184467440737095516, 0.63, 0.625),
+        (74, 2213609288845146192, 184467440737095516, 0.75, 0.75),
+        (81, 1291272085159668612, 184467440737095516, 0.82, 0.8125),
+        (87, 1106804644422573096, 184467440737095516, 0.88, 0.875),
+        (90, 553402322211286548, 184467440737095516, 0.91, 0.90625),
+        (93, 553402322211286548, 184467440737095516, 0.94, 0.9375),
+        (95, 368934881474191032, 184467440737095516, 0.96, 0.953125),
+        (96, 184467440737095516, 184467440737095516, 0.97, 0.96875),
+        (97, 184467440737095516, 184467440737095516, 0.98, 0.9765625),
+        (98, 184467440737095516, 184467440737095516, 0.99, 0.984375),
+        (98, 0, 184467440737095516, 0.99, 0.98828125),
+        (99, 184467440737095516, 184467440737095516, 1.0, 0.9921875),
+        (99, 0, 184467440737095516, 1.0, 0.994140625),
+        (99, 0, 184467440737095516, 1.0, 0.99609375),
+        (99, 0, 184467440737095516, 1.0, 0.9970703125),
+        (99, 0, 184467440737095516, 1.0, 0.998046875),
+        (99, 0, 184467440737095516, 1.0, 0.99853515625),
+        (99, 0, 184467440737095516, 1.0, 0.9990234375),
+        (99, 0, 184467440737095516, 1.0, 0.999267578125),
+        (99, 0, 184467440737095516, 1.0, 0.99951171875),
+        (99, 0, 184467440737095516, 1.0, 0.9996337890625),
+        (99, 0, 184467440737095516, 1.0, 0.999755859375),
+        (99, 0, 184467440737095516, 1.0, 0.99981689453125),
+        (99, 0, 184467440737095516, 1.0, 0.9998779296875),
+        (99, 0, 184467440737095516, 1.0, 0.999908447265625),
+        (99, 0, 184467440737095516, 1.0, 0.99993896484375),
+        (99, 0, 184467440737095516, 1.0, 0.9999542236328125),
+        (99, 0, 184467440737095516, 1.0, 0.999969482421875),
+        (99, 0, 184467440737095516, 1.0, 0.9999771118164063),
+        (99, 0, 184467440737095516, 1.0, 0.9999847412109375),
+        (99, 0, 184467440737095516, 1.0, 0.9999885559082031),
+        (99, 0, 184467440737095516, 1.0, 0.9999923706054688),
+        (99, 0, 184467440737095516, 1.0, 0.9999942779541016),
+        (99, 0, 184467440737095516, 1.0, 0.9999961853027344),
+        (99, 0, 184467440737095516, 1.0, 0.9999971389770508),
+        (99, 0, 184467440737095516, 1.0, 0.9999980926513672),
+        (99, 0, 184467440737095516, 1.0, 0.9999985694885254),
+        (99, 0, 184467440737095516, 1.0, 0.9999990463256836),
+        (99, 0, 184467440737095516, 1.0, 0.9999992847442627),
+        (99, 0, 184467440737095516, 1.0, 0.9999995231628418),
+        (99, 0, 184467440737095516, 1.0, 0.9999996423721313),
+        (99, 0, 184467440737095516, 1.0, 0.9999997615814209),
+        (99, 0, 184467440737095516, 1.0, 0.9999998211860657),
+        (99, 0, 184467440737095516, 1.0, 0.9999998807907104),
+        (99, 0, 184467440737095516, 1.0, 0.9999999105930328),
+        (99, 0, 184467440737095516, 1.0, 0.9999999403953552),
+        (99, 0, 184467440737095516, 1.0, 0.9999999552965164),
+        (99, 0, 184467440737095516, 1.0, 0.9999999701976776),
+        (99, 0, 184467440737095516, 1.0, 0.9999999776482582),
+        (99, 0, 184467440737095516, 1.0, 0.9999999850988388),
+        (99, 0, 184467440737095516, 1.0, 0.9999999888241291),
+        (99, 0, 184467440737095516, 1.0, 0.9999999925494194),
+        (99, 0, 184467440737095516, 1.0, 0.9999999944120646),
+        (99, 0, 184467440737095516, 1.0, 0.9999999962747097),
+        (99, 0, 184467440737095516, 1.0, 0.9999999972060323),
+        (99, 0, 184467440737095516, 1.0, 0.9999999981373549),
+        (99, 0, 184467440737095516, 1.0, 0.9999999986030161),
+        (99, 0, 184467440737095516, 1.0, 0.9999999990686774),
+        (99, 0, 184467440737095516, 1.0, 0.9999999993015081),
+        (99, 0, 184467440737095516, 1.0, 0.9999999995343387),
+        (99, 0, 184467440737095516, 1.0, 0.999999999650754),
+        (99, 0, 184467440737095516, 1.0, 0.9999999997671694),
+        (99, 0, 184467440737095516, 1.0, 0.999999999825377),
+        (99, 0, 184467440737095516, 1.0, 0.9999999998835847),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999126885),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999417923),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999563443),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999708962),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999781721),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999854481),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999890861),
+        (99, 0, 184467440737095516, 1.0, 0.999999999992724),
+        (99, 0, 184467440737095516, 1.0, 0.999999999994543),
+        (99, 0, 184467440737095516, 1.0, 0.999999999996362),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999972715),
+        (99, 0, 184467440737095516, 1.0, 0.999999999998181),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999986358),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999990905),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999993179),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999995453),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999996589),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999997726),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999998295),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999998863),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999147),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999432),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999574),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999716),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999787),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999858),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999893),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999929),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999947),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999964),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999973),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999982),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999987),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999991),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999993),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999996),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999997),
+        (99, 0, 184467440737095516, 1.0, 0.9999999999999998),
+        // at 0.99...98, adding the resulting increment = the same 0.999...9998.
+        // The increment calculations at this point involve 1 / (1 << 54), and f64
+        // has 53 significand bits, so it's not too surprising that this is where
+        // things get noticeably imprecise.
+        (99, 0, 184467440737095516, 1.0, 1.0),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -653,120 +710,126 @@ fn iter_quantiles_iterates_to_quantile_10_as_it_reaches_last_bucket() {
     h.record_n(2, 2).unwrap();
 
     let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
-            .map(|v| (v.value_iterated_to(),
-                      v.count_since_last_iteration(),
-                      v.count_at_value(),
-                      v.quantile(),
-                      v.quantile_iterated_to()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+                v.quantile(),
+                v.quantile_iterated_to(),
+            )
+        })
+        .collect();
 
-    let expected = vec![(1, first_bucket, first_bucket, quantile, 0.0),
-                        (1, 0, first_bucket, quantile, 0.25),
-                        (1, 0, first_bucket, quantile, 0.5),
-                        (1, 0, first_bucket, quantile, 0.625),
-                        (1, 0, first_bucket, quantile, 0.75),
-                        (1, 0, first_bucket, quantile, 0.8125),
-                        (1, 0, first_bucket, quantile, 0.875),
-                        (1, 0, first_bucket, quantile, 0.90625),
-                        (1, 0, first_bucket, quantile, 0.9375),
-                        (1, 0, first_bucket, quantile, 0.953125),
-                        (1, 0, first_bucket, quantile, 0.96875),
-                        (1, 0, first_bucket, quantile, 0.9765625),
-                        (1, 0, first_bucket, quantile, 0.984375),
-                        (1, 0, first_bucket, quantile, 0.98828125),
-                        (1, 0, first_bucket, quantile, 0.9921875),
-                        (1, 0, first_bucket, quantile, 0.994140625),
-                        (1, 0, first_bucket, quantile, 0.99609375),
-                        (1, 0, first_bucket, quantile, 0.9970703125),
-                        (1, 0, first_bucket, quantile, 0.998046875),
-                        (1, 0, first_bucket, quantile, 0.99853515625),
-                        (1, 0, first_bucket, quantile, 0.9990234375),
-                        (1, 0, first_bucket, quantile, 0.999267578125),
-                        (1, 0, first_bucket, quantile, 0.99951171875),
-                        (1, 0, first_bucket, quantile, 0.9996337890625),
-                        (1, 0, first_bucket, quantile, 0.999755859375),
-                        (1, 0, first_bucket, quantile, 0.99981689453125),
-                        (1, 0, first_bucket, quantile, 0.9998779296875),
-                        (1, 0, first_bucket, quantile, 0.999908447265625),
-                        (1, 0, first_bucket, quantile, 0.99993896484375),
-                        (1, 0, first_bucket, quantile, 0.9999542236328125),
-                        (1, 0, first_bucket, quantile, 0.999969482421875),
-                        (1, 0, first_bucket, quantile, 0.9999771118164063),
-                        (1, 0, first_bucket, quantile, 0.9999847412109375),
-                        (1, 0, first_bucket, quantile, 0.9999885559082031),
-                        (1, 0, first_bucket, quantile, 0.9999923706054688),
-                        (1, 0, first_bucket, quantile, 0.9999942779541016),
-                        (1, 0, first_bucket, quantile, 0.9999961853027344),
-                        (1, 0, first_bucket, quantile, 0.9999971389770508),
-                        (1, 0, first_bucket, quantile, 0.9999980926513672),
-                        (1, 0, first_bucket, quantile, 0.9999985694885254),
-                        (1, 0, first_bucket, quantile, 0.9999990463256836),
-                        (1, 0, first_bucket, quantile, 0.9999992847442627),
-                        (1, 0, first_bucket, quantile, 0.9999995231628418),
-                        (1, 0, first_bucket, quantile, 0.9999996423721313),
-                        (1, 0, first_bucket, quantile, 0.9999997615814209),
-                        (1, 0, first_bucket, quantile, 0.9999998211860657),
-                        (1, 0, first_bucket, quantile, 0.9999998807907104),
-                        (1, 0, first_bucket, quantile, 0.9999999105930328),
-                        (1, 0, first_bucket, quantile, 0.9999999403953552),
-                        (1, 0, first_bucket, quantile, 0.9999999552965164),
-                        (1, 0, first_bucket, quantile, 0.9999999701976776),
-                        (1, 0, first_bucket, quantile, 0.9999999776482582),
-                        (1, 0, first_bucket, quantile, 0.9999999850988388),
-                        (1, 0, first_bucket, quantile, 0.9999999888241291),
-                        (1, 0, first_bucket, quantile, 0.9999999925494194),
-                        (1, 0, first_bucket, quantile, 0.9999999944120646),
-                        (1, 0, first_bucket, quantile, 0.9999999962747097),
-                        (1, 0, first_bucket, quantile, 0.9999999972060323),
-                        (1, 0, first_bucket, quantile, 0.9999999981373549),
-                        (1, 0, first_bucket, quantile, 0.9999999986030161),
-                        (1, 0, first_bucket, quantile, 0.9999999990686774),
-                        (1, 0, first_bucket, quantile, 0.9999999993015081),
-                        (1, 0, first_bucket, quantile, 0.9999999995343387),
-                        (1, 0, first_bucket, quantile, 0.999999999650754),
-                        (1, 0, first_bucket, quantile, 0.9999999997671694),
-                        (1, 0, first_bucket, quantile, 0.999999999825377),
-                        (1, 0, first_bucket, quantile, 0.9999999998835847),
-                        (1, 0, first_bucket, quantile, 0.9999999999126885),
-                        (1, 0, first_bucket, quantile, 0.9999999999417923),
-                        (1, 0, first_bucket, quantile, 0.9999999999563443),
-                        (1, 0, first_bucket, quantile, 0.9999999999708962),
-                        (1, 0, first_bucket, quantile, 0.9999999999781721),
-                        (1, 0, first_bucket, quantile, 0.9999999999854481),
-                        (1, 0, first_bucket, quantile, 0.9999999999890861),
-                        (1, 0, first_bucket, quantile, 0.999999999992724),
-                        (1, 0, first_bucket, quantile, 0.999999999994543),
-                        (1, 0, first_bucket, quantile, 0.999999999996362),
-                        (1, 0, first_bucket, quantile, 0.9999999999972715),
-                        (1, 0, first_bucket, quantile, 0.999999999998181),
-                        (1, 0, first_bucket, quantile, 0.9999999999986358),
-                        (1, 0, first_bucket, quantile, 0.9999999999990905),
-                        (1, 0, first_bucket, quantile, 0.9999999999993179),
-                        (1, 0, first_bucket, quantile, 0.9999999999995453),
-                        (1, 0, first_bucket, quantile, 0.9999999999996589),
-                        (1, 0, first_bucket, quantile, 0.9999999999997726),
-                        (1, 0, first_bucket, quantile, 0.9999999999998295),
-                        (1, 0, first_bucket, quantile, 0.9999999999998863),
-                        (1, 0, first_bucket, quantile, 0.9999999999999147),
-                        (1, 0, first_bucket, quantile, 0.9999999999999432),
-                        (1, 0, first_bucket, quantile, 0.9999999999999574),
-                        (1, 0, first_bucket, quantile, 0.9999999999999716),
-                        (1, 0, first_bucket, quantile, 0.9999999999999787),
-                        (1, 0, first_bucket, quantile, 0.9999999999999858),
-                        (1, 0, first_bucket, quantile, 0.9999999999999893),
-                        (1, 0, first_bucket, quantile, 0.9999999999999929),
-                        (1, 0, first_bucket, quantile, 0.9999999999999947),
-                        (1, 0, first_bucket, quantile, 0.9999999999999964),
-                        (1, 0, first_bucket, quantile, 0.9999999999999973),
-                        (1, 0, first_bucket, quantile, 0.9999999999999982),
-                        (1, 0, first_bucket, quantile, 0.9999999999999987),
-                        (1, 0, first_bucket, quantile, 0.9999999999999991),
-                        (1, 0, first_bucket, quantile, 0.9999999999999993),
-                        (1, 0, first_bucket, quantile, 0.9999999999999996),
-                        (1, 0, first_bucket, quantile, 0.9999999999999997),
-                        (1, 0, first_bucket, quantile, 0.9999999999999998),
-                        // goes to next bucket just as it reaches 1.0
-                        (2, 2, 2, 1.0, 1.0)];
+    let expected = vec![
+        (1, first_bucket, first_bucket, quantile, 0.0),
+        (1, 0, first_bucket, quantile, 0.25),
+        (1, 0, first_bucket, quantile, 0.5),
+        (1, 0, first_bucket, quantile, 0.625),
+        (1, 0, first_bucket, quantile, 0.75),
+        (1, 0, first_bucket, quantile, 0.8125),
+        (1, 0, first_bucket, quantile, 0.875),
+        (1, 0, first_bucket, quantile, 0.90625),
+        (1, 0, first_bucket, quantile, 0.9375),
+        (1, 0, first_bucket, quantile, 0.953125),
+        (1, 0, first_bucket, quantile, 0.96875),
+        (1, 0, first_bucket, quantile, 0.9765625),
+        (1, 0, first_bucket, quantile, 0.984375),
+        (1, 0, first_bucket, quantile, 0.98828125),
+        (1, 0, first_bucket, quantile, 0.9921875),
+        (1, 0, first_bucket, quantile, 0.994140625),
+        (1, 0, first_bucket, quantile, 0.99609375),
+        (1, 0, first_bucket, quantile, 0.9970703125),
+        (1, 0, first_bucket, quantile, 0.998046875),
+        (1, 0, first_bucket, quantile, 0.99853515625),
+        (1, 0, first_bucket, quantile, 0.9990234375),
+        (1, 0, first_bucket, quantile, 0.999267578125),
+        (1, 0, first_bucket, quantile, 0.99951171875),
+        (1, 0, first_bucket, quantile, 0.9996337890625),
+        (1, 0, first_bucket, quantile, 0.999755859375),
+        (1, 0, first_bucket, quantile, 0.99981689453125),
+        (1, 0, first_bucket, quantile, 0.9998779296875),
+        (1, 0, first_bucket, quantile, 0.999908447265625),
+        (1, 0, first_bucket, quantile, 0.99993896484375),
+        (1, 0, first_bucket, quantile, 0.9999542236328125),
+        (1, 0, first_bucket, quantile, 0.999969482421875),
+        (1, 0, first_bucket, quantile, 0.9999771118164063),
+        (1, 0, first_bucket, quantile, 0.9999847412109375),
+        (1, 0, first_bucket, quantile, 0.9999885559082031),
+        (1, 0, first_bucket, quantile, 0.9999923706054688),
+        (1, 0, first_bucket, quantile, 0.9999942779541016),
+        (1, 0, first_bucket, quantile, 0.9999961853027344),
+        (1, 0, first_bucket, quantile, 0.9999971389770508),
+        (1, 0, first_bucket, quantile, 0.9999980926513672),
+        (1, 0, first_bucket, quantile, 0.9999985694885254),
+        (1, 0, first_bucket, quantile, 0.9999990463256836),
+        (1, 0, first_bucket, quantile, 0.9999992847442627),
+        (1, 0, first_bucket, quantile, 0.9999995231628418),
+        (1, 0, first_bucket, quantile, 0.9999996423721313),
+        (1, 0, first_bucket, quantile, 0.9999997615814209),
+        (1, 0, first_bucket, quantile, 0.9999998211860657),
+        (1, 0, first_bucket, quantile, 0.9999998807907104),
+        (1, 0, first_bucket, quantile, 0.9999999105930328),
+        (1, 0, first_bucket, quantile, 0.9999999403953552),
+        (1, 0, first_bucket, quantile, 0.9999999552965164),
+        (1, 0, first_bucket, quantile, 0.9999999701976776),
+        (1, 0, first_bucket, quantile, 0.9999999776482582),
+        (1, 0, first_bucket, quantile, 0.9999999850988388),
+        (1, 0, first_bucket, quantile, 0.9999999888241291),
+        (1, 0, first_bucket, quantile, 0.9999999925494194),
+        (1, 0, first_bucket, quantile, 0.9999999944120646),
+        (1, 0, first_bucket, quantile, 0.9999999962747097),
+        (1, 0, first_bucket, quantile, 0.9999999972060323),
+        (1, 0, first_bucket, quantile, 0.9999999981373549),
+        (1, 0, first_bucket, quantile, 0.9999999986030161),
+        (1, 0, first_bucket, quantile, 0.9999999990686774),
+        (1, 0, first_bucket, quantile, 0.9999999993015081),
+        (1, 0, first_bucket, quantile, 0.9999999995343387),
+        (1, 0, first_bucket, quantile, 0.999999999650754),
+        (1, 0, first_bucket, quantile, 0.9999999997671694),
+        (1, 0, first_bucket, quantile, 0.999999999825377),
+        (1, 0, first_bucket, quantile, 0.9999999998835847),
+        (1, 0, first_bucket, quantile, 0.9999999999126885),
+        (1, 0, first_bucket, quantile, 0.9999999999417923),
+        (1, 0, first_bucket, quantile, 0.9999999999563443),
+        (1, 0, first_bucket, quantile, 0.9999999999708962),
+        (1, 0, first_bucket, quantile, 0.9999999999781721),
+        (1, 0, first_bucket, quantile, 0.9999999999854481),
+        (1, 0, first_bucket, quantile, 0.9999999999890861),
+        (1, 0, first_bucket, quantile, 0.999999999992724),
+        (1, 0, first_bucket, quantile, 0.999999999994543),
+        (1, 0, first_bucket, quantile, 0.999999999996362),
+        (1, 0, first_bucket, quantile, 0.9999999999972715),
+        (1, 0, first_bucket, quantile, 0.999999999998181),
+        (1, 0, first_bucket, quantile, 0.9999999999986358),
+        (1, 0, first_bucket, quantile, 0.9999999999990905),
+        (1, 0, first_bucket, quantile, 0.9999999999993179),
+        (1, 0, first_bucket, quantile, 0.9999999999995453),
+        (1, 0, first_bucket, quantile, 0.9999999999996589),
+        (1, 0, first_bucket, quantile, 0.9999999999997726),
+        (1, 0, first_bucket, quantile, 0.9999999999998295),
+        (1, 0, first_bucket, quantile, 0.9999999999998863),
+        (1, 0, first_bucket, quantile, 0.9999999999999147),
+        (1, 0, first_bucket, quantile, 0.9999999999999432),
+        (1, 0, first_bucket, quantile, 0.9999999999999574),
+        (1, 0, first_bucket, quantile, 0.9999999999999716),
+        (1, 0, first_bucket, quantile, 0.9999999999999787),
+        (1, 0, first_bucket, quantile, 0.9999999999999858),
+        (1, 0, first_bucket, quantile, 0.9999999999999893),
+        (1, 0, first_bucket, quantile, 0.9999999999999929),
+        (1, 0, first_bucket, quantile, 0.9999999999999947),
+        (1, 0, first_bucket, quantile, 0.9999999999999964),
+        (1, 0, first_bucket, quantile, 0.9999999999999973),
+        (1, 0, first_bucket, quantile, 0.9999999999999982),
+        (1, 0, first_bucket, quantile, 0.9999999999999987),
+        (1, 0, first_bucket, quantile, 0.9999999999999991),
+        (1, 0, first_bucket, quantile, 0.9999999999999993),
+        (1, 0, first_bucket, quantile, 0.9999999999999996),
+        (1, 0, first_bucket, quantile, 0.9999999999999997),
+        (1, 0, first_bucket, quantile, 0.9999999999999998),
+        // goes to next bucket just as it reaches 1.0
+        (2, 2, 2, 1.0, 1.0),
+    ];
 
     assert_eq!(expected, iter_values);
 }
@@ -778,17 +841,19 @@ fn iter_quantiles_one_value() {
     h.record_n(1, 1).unwrap();
 
     let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
-            .map(|v| (v.value_iterated_to(),
-                      v.count_since_last_iteration(),
-                      v.count_at_value(),
-                      v.quantile(),
-                      v.quantile_iterated_to()))
-            .collect();
+        .map(|v| {
+            (
+                v.value_iterated_to(),
+                v.count_since_last_iteration(),
+                v.count_at_value(),
+                v.quantile(),
+                v.quantile_iterated_to(),
+            )
+        })
+        .collect();
 
     // at first iteration, we're already in the last index, so we should jump to 1.0 and stop
-    let expected = vec![
-        (1, 1, 1, 1.0, 0.0),
-        (1, 0, 1, 1.0, 1.0)];
+    let expected = vec![(1, 1, 1, 1.0, 0.0), (1, 0, 1, 1.0, 1.0)];
 
     assert_eq!(expected, iter_values);
 }
@@ -823,6 +888,14 @@ fn prepare_histo_for_logarithmic_iterator() -> Histogram<u64> {
     h
 }
 
-fn histo64(lowest_discernible_value: u64, highest_trackable_value: u64, num_significant_digits: u8) -> Histogram<u64> {
-    Histogram::<u64>::new_with_bounds(lowest_discernible_value, highest_trackable_value, num_significant_digits).unwrap()
+fn histo64(
+    lowest_discernible_value: u64,
+    highest_trackable_value: u64,
+    num_significant_digits: u8,
+) -> Histogram<u64> {
+    Histogram::<u64>::new_with_bounds(
+        lowest_discernible_value,
+        highest_trackable_value,
+        num_significant_digits,
+    ).unwrap()
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -246,12 +246,7 @@ fn iter_recorded_values_all_buckets() {
         (4096 + 3, 1),
         (8192 - 1, 1)];
 
-    let nonzero_count = iter_values.iter()
-            .filter(|v| v.1 != 0)
-            .map(|&v| v)
-            .collect::<Vec<(u64, u64)>>();
-
-    assert_eq!(expected, nonzero_count);
+    assert_eq!(expected, iter_values);
 }
 
 #[test]
@@ -276,12 +271,7 @@ fn iter_recorded_values_all_buckets_unit_magnitude_2() {
         (8192 + 7, 1),
         (16384 - 1, 1)];
 
-    let nonzero_count = iter_values.iter()
-            .filter(|v| v.1 != 0)
-            .map(|&v| v)
-            .collect::<Vec<(u64, u64)>>();
-
-    assert_eq!(expected, nonzero_count);
+    assert_eq!(expected, iter_values);
 }
 
 #[test]
@@ -485,6 +475,329 @@ fn iter_quantiles_smorgasboard() {
         (4095, 0, 2, 1.0, 1.0)];
 
     assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_quantiles_iterates_to_end_skips_intermediate_at_final_value() {
+    let mut h = histo64(1, 4095, 3);
+
+    h.record_n(1, 1).unwrap();
+    h.record_n(1_000, 1_000_000).unwrap();
+
+    let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
+            .map(|v| (v.value_iterated_to(),
+                      v.count_since_last_iteration(),
+                      v.count_at_value(),
+                      v.quantile(),
+                      v.quantile_iterated_to()))
+            .collect();
+
+    // almost every nonzero quantile is in the bucket whose value is at quantile 1.0, so we should
+    // iterate into that bucket (at quantile iteration 0.25), then skip to quantile iteration 1.0
+    let expected = vec![
+        (1, 1, 1, 0.000000999999000001, 0.0),
+        (1000, 1000_000, 1000_000, 1.0, 0.25),
+        (1000, 0, 1000_000, 1.0, 1.0)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_quantiles_saturated_count_before_max_value() {
+    let mut h = histo64(1, 4095, 3);
+
+    for i in 0..1000 {
+        // this will quickly saturate total count as well as count since last iteration
+        h.record_n(i, u64::max_value() / 100).unwrap();
+    };
+
+    let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
+            .map(|v| (v.value_iterated_to(),
+                      v.count_since_last_iteration(),
+                      v.count_at_value(),
+                      v.quantile(),
+                      v.quantile_iterated_to()))
+            .collect();
+
+    // here we do NOT skip to 1.0 because we haven't detected that we're at the max value (because
+    // we aren't!).
+    // This will iterate towards quantile 1.0  and will reach a point where a fraction very close to
+    // 1.0 + a tiny tiny increment = the same fraction. It should then skip to 1.0.
+    let expected = vec![(0, 184467440737095516, 184467440737095516, 0.01, 0.0),
+                        (24, 4427218577690292384, 184467440737095516, 0.25, 0.25),
+                        (49, 4611686018427387900, 184467440737095516, 0.5, 0.5),
+                        (62, 2398076729582241708, 184467440737095516, 0.63, 0.625),
+                        (74, 2213609288845146192, 184467440737095516, 0.75, 0.75),
+                        (81, 1291272085159668612, 184467440737095516, 0.82, 0.8125),
+                        (87, 1106804644422573096, 184467440737095516, 0.88, 0.875),
+                        (90, 553402322211286548, 184467440737095516, 0.91, 0.90625),
+                        (93, 553402322211286548, 184467440737095516, 0.94, 0.9375),
+                        (95, 368934881474191032, 184467440737095516, 0.96, 0.953125),
+                        (96, 184467440737095516, 184467440737095516, 0.97, 0.96875),
+                        (97, 184467440737095516, 184467440737095516, 0.98, 0.9765625),
+                        (98, 184467440737095516, 184467440737095516, 0.99, 0.984375),
+                        (98, 0, 184467440737095516, 0.99, 0.98828125),
+                        (99, 184467440737095516, 184467440737095516, 1.0, 0.9921875),
+                        (99, 0, 184467440737095516, 1.0, 0.994140625),
+                        (99, 0, 184467440737095516, 1.0, 0.99609375),
+                        (99, 0, 184467440737095516, 1.0, 0.9970703125),
+                        (99, 0, 184467440737095516, 1.0, 0.998046875),
+                        (99, 0, 184467440737095516, 1.0, 0.99853515625),
+                        (99, 0, 184467440737095516, 1.0, 0.9990234375),
+                        (99, 0, 184467440737095516, 1.0, 0.999267578125),
+                        (99, 0, 184467440737095516, 1.0, 0.99951171875),
+                        (99, 0, 184467440737095516, 1.0, 0.9996337890625),
+                        (99, 0, 184467440737095516, 1.0, 0.999755859375),
+                        (99, 0, 184467440737095516, 1.0, 0.99981689453125),
+                        (99, 0, 184467440737095516, 1.0, 0.9998779296875),
+                        (99, 0, 184467440737095516, 1.0, 0.999908447265625),
+                        (99, 0, 184467440737095516, 1.0, 0.99993896484375),
+                        (99, 0, 184467440737095516, 1.0, 0.9999542236328125),
+                        (99, 0, 184467440737095516, 1.0, 0.999969482421875),
+                        (99, 0, 184467440737095516, 1.0, 0.9999771118164063),
+                        (99, 0, 184467440737095516, 1.0, 0.9999847412109375),
+                        (99, 0, 184467440737095516, 1.0, 0.9999885559082031),
+                        (99, 0, 184467440737095516, 1.0, 0.9999923706054688),
+                        (99, 0, 184467440737095516, 1.0, 0.9999942779541016),
+                        (99, 0, 184467440737095516, 1.0, 0.9999961853027344),
+                        (99, 0, 184467440737095516, 1.0, 0.9999971389770508),
+                        (99, 0, 184467440737095516, 1.0, 0.9999980926513672),
+                        (99, 0, 184467440737095516, 1.0, 0.9999985694885254),
+                        (99, 0, 184467440737095516, 1.0, 0.9999990463256836),
+                        (99, 0, 184467440737095516, 1.0, 0.9999992847442627),
+                        (99, 0, 184467440737095516, 1.0, 0.9999995231628418),
+                        (99, 0, 184467440737095516, 1.0, 0.9999996423721313),
+                        (99, 0, 184467440737095516, 1.0, 0.9999997615814209),
+                        (99, 0, 184467440737095516, 1.0, 0.9999998211860657),
+                        (99, 0, 184467440737095516, 1.0, 0.9999998807907104),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999105930328),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999403953552),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999552965164),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999701976776),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999776482582),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999850988388),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999888241291),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999925494194),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999944120646),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999962747097),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999972060323),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999981373549),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999986030161),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999990686774),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999993015081),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999995343387),
+                        (99, 0, 184467440737095516, 1.0, 0.999999999650754),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999997671694),
+                        (99, 0, 184467440737095516, 1.0, 0.999999999825377),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999998835847),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999126885),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999417923),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999563443),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999708962),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999781721),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999854481),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999890861),
+                        (99, 0, 184467440737095516, 1.0, 0.999999999992724),
+                        (99, 0, 184467440737095516, 1.0, 0.999999999994543),
+                        (99, 0, 184467440737095516, 1.0, 0.999999999996362),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999972715),
+                        (99, 0, 184467440737095516, 1.0, 0.999999999998181),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999986358),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999990905),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999993179),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999995453),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999996589),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999997726),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999998295),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999998863),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999147),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999432),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999574),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999716),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999787),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999858),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999893),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999929),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999947),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999964),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999973),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999982),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999987),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999991),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999993),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999996),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999997),
+                        (99, 0, 184467440737095516, 1.0, 0.9999999999999998),
+                        // at 0.99...98, adding the resulting increment = the same 0.999...9998.
+                        // The increment calculations at this point involve 1 / (1 << 54), and f64
+                        // has 53 significand bits, so it's not too surprising that this is where
+                        // things get noticeably imprecise.
+                        (99, 0, 184467440737095516, 1.0, 1.0)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_quantiles_iterates_to_quantile_10_as_it_reaches_last_bucket() {
+    let mut h = histo64(1, 4095, 3);
+
+    // at 2 ticks per half distance, 0.9999999999999998 is the largest quantile we can get to before
+    // 1.0. So, we craft a histogram that has that much before the last bucket.
+
+    let total = 10_000_000_000_000_000_u64;
+    let quantile = 0.9999999999999998_f64;
+    let first_bucket = (quantile * total as f64) as u64;
+    assert_eq!(9999999999999998, first_bucket);
+    h.record_n(1, first_bucket).unwrap();
+    // and now the leftovers to reach the total
+    h.record_n(2, 2).unwrap();
+
+    let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
+            .map(|v| (v.value_iterated_to(),
+                      v.count_since_last_iteration(),
+                      v.count_at_value(),
+                      v.quantile(),
+                      v.quantile_iterated_to()))
+            .collect();
+
+    let expected = vec![(1, first_bucket, first_bucket, quantile, 0.0),
+                        (1, 0, first_bucket, quantile, 0.25),
+                        (1, 0, first_bucket, quantile, 0.5),
+                        (1, 0, first_bucket, quantile, 0.625),
+                        (1, 0, first_bucket, quantile, 0.75),
+                        (1, 0, first_bucket, quantile, 0.8125),
+                        (1, 0, first_bucket, quantile, 0.875),
+                        (1, 0, first_bucket, quantile, 0.90625),
+                        (1, 0, first_bucket, quantile, 0.9375),
+                        (1, 0, first_bucket, quantile, 0.953125),
+                        (1, 0, first_bucket, quantile, 0.96875),
+                        (1, 0, first_bucket, quantile, 0.9765625),
+                        (1, 0, first_bucket, quantile, 0.984375),
+                        (1, 0, first_bucket, quantile, 0.98828125),
+                        (1, 0, first_bucket, quantile, 0.9921875),
+                        (1, 0, first_bucket, quantile, 0.994140625),
+                        (1, 0, first_bucket, quantile, 0.99609375),
+                        (1, 0, first_bucket, quantile, 0.9970703125),
+                        (1, 0, first_bucket, quantile, 0.998046875),
+                        (1, 0, first_bucket, quantile, 0.99853515625),
+                        (1, 0, first_bucket, quantile, 0.9990234375),
+                        (1, 0, first_bucket, quantile, 0.999267578125),
+                        (1, 0, first_bucket, quantile, 0.99951171875),
+                        (1, 0, first_bucket, quantile, 0.9996337890625),
+                        (1, 0, first_bucket, quantile, 0.999755859375),
+                        (1, 0, first_bucket, quantile, 0.99981689453125),
+                        (1, 0, first_bucket, quantile, 0.9998779296875),
+                        (1, 0, first_bucket, quantile, 0.999908447265625),
+                        (1, 0, first_bucket, quantile, 0.99993896484375),
+                        (1, 0, first_bucket, quantile, 0.9999542236328125),
+                        (1, 0, first_bucket, quantile, 0.999969482421875),
+                        (1, 0, first_bucket, quantile, 0.9999771118164063),
+                        (1, 0, first_bucket, quantile, 0.9999847412109375),
+                        (1, 0, first_bucket, quantile, 0.9999885559082031),
+                        (1, 0, first_bucket, quantile, 0.9999923706054688),
+                        (1, 0, first_bucket, quantile, 0.9999942779541016),
+                        (1, 0, first_bucket, quantile, 0.9999961853027344),
+                        (1, 0, first_bucket, quantile, 0.9999971389770508),
+                        (1, 0, first_bucket, quantile, 0.9999980926513672),
+                        (1, 0, first_bucket, quantile, 0.9999985694885254),
+                        (1, 0, first_bucket, quantile, 0.9999990463256836),
+                        (1, 0, first_bucket, quantile, 0.9999992847442627),
+                        (1, 0, first_bucket, quantile, 0.9999995231628418),
+                        (1, 0, first_bucket, quantile, 0.9999996423721313),
+                        (1, 0, first_bucket, quantile, 0.9999997615814209),
+                        (1, 0, first_bucket, quantile, 0.9999998211860657),
+                        (1, 0, first_bucket, quantile, 0.9999998807907104),
+                        (1, 0, first_bucket, quantile, 0.9999999105930328),
+                        (1, 0, first_bucket, quantile, 0.9999999403953552),
+                        (1, 0, first_bucket, quantile, 0.9999999552965164),
+                        (1, 0, first_bucket, quantile, 0.9999999701976776),
+                        (1, 0, first_bucket, quantile, 0.9999999776482582),
+                        (1, 0, first_bucket, quantile, 0.9999999850988388),
+                        (1, 0, first_bucket, quantile, 0.9999999888241291),
+                        (1, 0, first_bucket, quantile, 0.9999999925494194),
+                        (1, 0, first_bucket, quantile, 0.9999999944120646),
+                        (1, 0, first_bucket, quantile, 0.9999999962747097),
+                        (1, 0, first_bucket, quantile, 0.9999999972060323),
+                        (1, 0, first_bucket, quantile, 0.9999999981373549),
+                        (1, 0, first_bucket, quantile, 0.9999999986030161),
+                        (1, 0, first_bucket, quantile, 0.9999999990686774),
+                        (1, 0, first_bucket, quantile, 0.9999999993015081),
+                        (1, 0, first_bucket, quantile, 0.9999999995343387),
+                        (1, 0, first_bucket, quantile, 0.999999999650754),
+                        (1, 0, first_bucket, quantile, 0.9999999997671694),
+                        (1, 0, first_bucket, quantile, 0.999999999825377),
+                        (1, 0, first_bucket, quantile, 0.9999999998835847),
+                        (1, 0, first_bucket, quantile, 0.9999999999126885),
+                        (1, 0, first_bucket, quantile, 0.9999999999417923),
+                        (1, 0, first_bucket, quantile, 0.9999999999563443),
+                        (1, 0, first_bucket, quantile, 0.9999999999708962),
+                        (1, 0, first_bucket, quantile, 0.9999999999781721),
+                        (1, 0, first_bucket, quantile, 0.9999999999854481),
+                        (1, 0, first_bucket, quantile, 0.9999999999890861),
+                        (1, 0, first_bucket, quantile, 0.999999999992724),
+                        (1, 0, first_bucket, quantile, 0.999999999994543),
+                        (1, 0, first_bucket, quantile, 0.999999999996362),
+                        (1, 0, first_bucket, quantile, 0.9999999999972715),
+                        (1, 0, first_bucket, quantile, 0.999999999998181),
+                        (1, 0, first_bucket, quantile, 0.9999999999986358),
+                        (1, 0, first_bucket, quantile, 0.9999999999990905),
+                        (1, 0, first_bucket, quantile, 0.9999999999993179),
+                        (1, 0, first_bucket, quantile, 0.9999999999995453),
+                        (1, 0, first_bucket, quantile, 0.9999999999996589),
+                        (1, 0, first_bucket, quantile, 0.9999999999997726),
+                        (1, 0, first_bucket, quantile, 0.9999999999998295),
+                        (1, 0, first_bucket, quantile, 0.9999999999998863),
+                        (1, 0, first_bucket, quantile, 0.9999999999999147),
+                        (1, 0, first_bucket, quantile, 0.9999999999999432),
+                        (1, 0, first_bucket, quantile, 0.9999999999999574),
+                        (1, 0, first_bucket, quantile, 0.9999999999999716),
+                        (1, 0, first_bucket, quantile, 0.9999999999999787),
+                        (1, 0, first_bucket, quantile, 0.9999999999999858),
+                        (1, 0, first_bucket, quantile, 0.9999999999999893),
+                        (1, 0, first_bucket, quantile, 0.9999999999999929),
+                        (1, 0, first_bucket, quantile, 0.9999999999999947),
+                        (1, 0, first_bucket, quantile, 0.9999999999999964),
+                        (1, 0, first_bucket, quantile, 0.9999999999999973),
+                        (1, 0, first_bucket, quantile, 0.9999999999999982),
+                        (1, 0, first_bucket, quantile, 0.9999999999999987),
+                        (1, 0, first_bucket, quantile, 0.9999999999999991),
+                        (1, 0, first_bucket, quantile, 0.9999999999999993),
+                        (1, 0, first_bucket, quantile, 0.9999999999999996),
+                        (1, 0, first_bucket, quantile, 0.9999999999999997),
+                        (1, 0, first_bucket, quantile, 0.9999999999999998),
+                        // goes to next bucket just as it reaches 1.0
+                        (2, 2, 2, 1.0, 1.0)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_quantiles_one_value() {
+    let mut h = histo64(1, 4095, 3);
+
+    h.record_n(1, 1).unwrap();
+
+    let iter_values: Vec<(u64, u64, u64, f64, f64)> = h.iter_quantiles(2)
+            .map(|v| (v.value_iterated_to(),
+                      v.count_since_last_iteration(),
+                      v.count_at_value(),
+                      v.quantile(),
+                      v.quantile_iterated_to()))
+            .collect();
+
+    // at first iteration, we're already in the last index, so we should jump to 1.0 and stop
+    let expected = vec![
+        (1, 1, 1, 1.0, 0.0),
+        (1, 0, 1, 1.0, 1.0)];
+
+    assert_eq!(expected, iter_values);
+}
+
+#[test]
+fn iter_quantiles_empty() {
+    let h = histo64(1, 4095, 3);
+
+    assert_eq!(0, h.iter_quantiles(2).count());
 }
 
 fn prepare_histo_for_logarithmic_iterator() -> Histogram<u64> {

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -12,7 +12,7 @@ fn iter_recorded_non_saturated_total_count() {
 
     let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
     assert_eq!(expected, h.iter_recorded()
-        .map(|iv| iv.value())
+        .map(|iv| iv.value_iterated_to())
         .collect::<Vec<u64>>());
 }
 
@@ -26,6 +26,121 @@ fn iter_recorded_saturated_total_count() {
 
     let expected = vec![1, 1_000, h.highest_equivalent(1_000_000)];
     assert_eq!(expected, h.iter_recorded()
-        .map(|iv| iv.value())
+        .map(|iv| iv.value_iterated_to())
         .collect::<Vec<u64>>());
+}
+
+#[test]
+fn iter_linear_count_since_last_iteration_saturates() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    h.record_n(1, u64::max_value()).unwrap();
+    h.record_n(4, u64::max_value() - 1).unwrap();
+    h.record_n(5, u64::max_value() - 1).unwrap();
+    h.record_n(6, 100).unwrap();
+    h.record_n(7, 200).unwrap();
+    h.record_n(10, 400).unwrap();
+
+    let expected = vec![
+        // 0-1 has 1's max value
+        (1, u64::max_value()),
+        // 2-3 has nothing
+        (3, 0),
+        // 4-5 has 2x (max - 1), should saturate
+        (5, u64::max_value()),
+        // 6-7 shouldn't be saturated from 4-5
+        (7, 300),
+        // 8-9 has nothing
+        (9, 0),
+        // 10-11 has just 10's count
+        (11, 400)];
+
+    // step in 2s to test count accumulation for each step
+    assert_eq!(expected, h.iter_linear(2)
+            .map(|iv| (iv.value_iterated_to(), iv.count_since_last_iteration()))
+            .collect::<Vec<(u64, u64)>>());
+}
+
+#[test]
+fn iter_linear_visits_buckets_wider_than_step_size_multiple_times() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    h.record(1).unwrap();
+    h.record(2047).unwrap();
+    // bucket size 2
+    h.record(2048).unwrap();
+    h.record(2049).unwrap();
+    h.record(4095).unwrap();
+    // bucket size 4
+    h.record(4096).unwrap();
+    h.record(4097).unwrap();
+    h.record(4098).unwrap();
+    h.record(4099).unwrap();
+    // 2nd bucket in size 4
+    h.record(4100).unwrap();
+
+    let iter_values = h.iter_linear(1)
+            .map(|iv| (iv.value_iterated_to(), iv.count_since_last_iteration()))
+            .collect::<Vec<(u64, u64)>>();
+
+    // bucket size 1
+    assert_eq!((0, 0), iter_values[0]);
+    assert_eq!((1, 1), iter_values[1]);
+    assert_eq!((2046, 0), iter_values[2046]);
+    assert_eq!((2047, 1), iter_values[2047]);
+    // bucket size 2
+    assert_eq!((2048, 2), iter_values[2048]);
+    assert_eq!((2049, 0), iter_values[2049]);
+    assert_eq!((2050, 0), iter_values[2050]);
+    assert_eq!((2051, 0), iter_values[2051]);
+    assert_eq!((4094, 1), iter_values[4094]);
+    assert_eq!((4095, 0), iter_values[4095]);
+    // bucket size 4
+    assert_eq!((4096, 4), iter_values[4096]);
+    assert_eq!((4097, 0), iter_values[4097]);
+    assert_eq!((4098, 0), iter_values[4098]);
+    assert_eq!((4099, 0), iter_values[4099]);
+    // also size 4, last bucket
+    assert_eq!((4100, 1), iter_values[4100]);
+    assert_eq!((4101, 0), iter_values[4101]);
+    assert_eq!((4102, 0), iter_values[4102]);
+    assert_eq!((4103, 0), iter_values[4103]);
+
+    assert_eq!(4104, iter_values.len());
+}
+
+#[test]
+fn iter_linear_visits_buckets_once_when_step_size_equals_bucket_size() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    h.record(1).unwrap();
+    h.record(2047).unwrap();
+    // bucket size 2
+    h.record(2048).unwrap();
+    h.record(2049).unwrap();
+    h.record(4095).unwrap();
+    // bucket size 4
+    h.record(4096).unwrap();
+    h.record(4097).unwrap();
+    h.record(4098).unwrap();
+    h.record(4099).unwrap();
+    // 2nd bucket in size 4
+    h.record(4100).unwrap();
+
+    let iter_values = h.iter_linear(4)
+            .map(|iv| (iv.value_iterated_to(), iv.count_since_last_iteration()))
+            .collect::<Vec<(u64, u64)>>();
+
+    // bucket size 1
+    assert_eq!((3, 1), iter_values[0]);
+    assert_eq!((2047, 1), iter_values[511]);
+    // bucket size 2
+    assert_eq!((2051, 2), iter_values[512]);
+    assert_eq!((4095, 1), iter_values[1023]);
+    // bucket size 4
+    assert_eq!((4099, 4), iter_values[1024]);
+    // also size 4, last bucket
+    assert_eq!((4103, 1), iter_values[1025]);
+
+    assert_eq!(1026, iter_values.len());
 }

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -1,0 +1,375 @@
+extern crate hdrsample;
+extern crate ieee754;
+extern crate rand;
+extern crate rug;
+
+use hdrsample::{Histogram, Counter};
+
+use rand::Rng;
+use rand::distributions::range::Range;
+use rand::distributions::IndependentSample;
+use ieee754::Ieee754;
+use rug::{Rational, Integer};
+
+#[test]
+fn value_at_quantile_internal_count_exceeds_bucket_type() {
+    let mut h: Histogram<u8> = Histogram::new(3).unwrap();
+
+    for _ in 0..200 {
+        h.record(100).unwrap();
+    }
+
+
+    for _ in 0..200 {
+        h.record(100_000).unwrap();
+    }
+
+    // we won't get back the original input because of bucketing
+    assert_eq!(h.highest_equivalent(100_000), h.value_at_quantile(1.0));
+}
+
+
+#[test]
+fn value_at_quantile_2_values() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    h.record(1).unwrap();
+    h.record(2).unwrap();
+
+    assert_eq!(1, h.value_at_quantile(0.25));
+    assert_eq!(1, h.value_at_quantile(0.5));
+
+    let almost_half = 0.5000000000000001;
+    let next = 0.5000000000000002;
+    // one ulp apart
+    assert_eq!(almost_half, 0.5_f64.next());
+    assert_eq!(next, almost_half.next());
+
+    assert_eq!(2, h.value_at_quantile(almost_half));
+    assert_eq!(2, h.value_at_quantile(next));
+}
+
+#[test]
+fn value_at_quantile_5_values() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    h.record(1).unwrap();
+    h.record(2).unwrap();
+    h.record(2).unwrap();
+    h.record(2).unwrap();
+    h.record(2).unwrap();
+
+    assert_eq!(2, h.value_at_quantile(0.25));
+    assert_eq!(2, h.value_at_quantile(0.3));
+}
+
+#[test]
+fn value_at_quantile_20k() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    for i in 1..20_001 {
+        h.record(i).unwrap();
+    }
+
+    assert_eq!(20_000, h.count());
+
+    assert!(h.equivalent(19961, h.value_at_quantile(0.99805)));
+}
+
+#[test]
+fn value_at_quantile_large_numbers() {
+    let mut h = Histogram::<u64>::new_with_bounds(20_000_000, 100_000_000, 5).unwrap();
+    h.record(100_000_000).unwrap();
+    h.record(20_000_000).unwrap();
+    h.record(30_000_000).unwrap();
+
+    assert!(h.equivalent(20_000_000, h.value_at_quantile(0.5)));
+    assert!(h.equivalent(30_000_000, h.value_at_quantile(0.5)));
+    assert!(h.equivalent(100_000_000, h.value_at_quantile(0.8333)));
+    assert!(h.equivalent(100_000_000, h.value_at_quantile(0.8334)));
+    assert!(h.equivalent(100_000_000, h.value_at_quantile(0.99)));
+}
+
+#[test]
+fn value_at_quantile_matches_quantile_iter_sequence_values() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
+    let mut errors: u64 = 0;
+
+    for length in lengths {
+        h.reset();
+
+        for i in 1..(length + 1) {
+            h.record(i).unwrap();
+        }
+
+        assert_eq!(length, h.count());
+
+        let iter = h.iter_quantiles(100);
+
+        for iter_val in iter {
+            let calculated_value = h.value_at_quantile(iter_val.quantile());
+            let v = iter_val.value();
+
+            // Quantile iteration has problematic floating-point calculations. Calculating the
+            // quantile involves something like `index / total_count`, and that's then multiplied
+            // by `total_count` again to get the value at the quantile. This tends to produce
+            // artifacts, so this test will frequently fail if you expect the actual value to
+            // match the calculated value. Instead, we allow it to be one bucket high or low.
+
+            if calculated_value != v
+                    && calculated_value != prev_value_nonzero_count(&h, v)
+                    && calculated_value != next_value_nonzero_count(&h, v) {
+                let q_count_rational = calculate_quantile_count(iter_val.quantile(), length);
+
+                println!("len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
+                         length, iter_val.quantile(), iter_val.quantile() * length as f64,
+                         q_count_rational, v, h.highest_equivalent(v),
+                         calculated_value, h.highest_equivalent(calculated_value));
+                errors += 1;
+            }
+        }
+    }
+
+    assert_eq!(0, errors);
+}
+
+#[test]
+fn value_at_quantile_matches_quantile_iter_random_values() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
+
+    let mut rng = rand::thread_rng();
+    let mut errors: u64 = 0;
+
+    for length in lengths {
+        h.reset();
+
+        for v in RandomMaxIter::new(&mut rng).take(length) {
+            h.record(v).unwrap();
+        }
+
+        assert_eq!(length as u64, h.count());
+
+        let iter = h.iter_quantiles(100);
+
+        for iter_val in iter {
+            let calculated_value = h.value_at_quantile(iter_val.quantile());
+            let v = iter_val.value();
+
+            // Quantile iteration has problematic floating-point calculations. Calculating the
+            // quantile involves something like `index / total_count`, and that's then multiplied
+            // by `total_count` again to get the value at the quantile. This tends to produce
+            // artifacts, so this test will frequently fail if you expect the actual value to
+            // match the calculated value. Instead, we allow it to be one bucket high or low.
+
+            if calculated_value != v
+                    && calculated_value != prev_value_nonzero_count(&h, v)
+                    && calculated_value != next_value_nonzero_count(&h, v) {
+                let q_count_rational = calculate_quantile_count(iter_val.quantile(), length as u64);
+
+                println!("len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
+                         length, iter_val.quantile(), iter_val.quantile() * length as f64,
+                         q_count_rational, v, h.highest_equivalent(v),
+                         calculated_value, h.highest_equivalent(calculated_value));
+                errors += 1;
+            }
+        }
+    }
+
+    assert_eq!(0, errors);
+}
+
+#[test]
+fn value_at_quantile_matches_quantile_at_each_value_sequence_values() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+
+    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
+    let mut errors: u64 = 0;
+
+    for length in lengths {
+        h.reset();
+
+        for i in 1..(length + 1) {
+            h.record(i).unwrap();
+        }
+
+        assert_eq!(length, h.count());
+
+        for v in 1..(length + 1) {
+            let quantile = (Rational::from(Integer::from(v as u64))
+                    / Rational::from(Integer::from(length as u64))).to_f64();
+            let calculated_value = h.value_at_quantile(quantile);
+            if !h.equivalent(v, calculated_value) {
+                println!("len {} value {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
+                         length, v, quantile, quantile * length as f64,
+                         v, h.highest_equivalent(v),
+                         calculated_value, h.highest_equivalent(calculated_value));
+                errors += 1;
+            }
+        }
+    }
+
+    assert_eq!(0, errors);
+}
+
+#[test]
+fn value_at_quantile_matches_quantile_at_each_value_random_values() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+    let mut values = Vec::new();
+
+    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
+
+    let mut rng = rand::thread_rng();
+
+    let mut errors: u64 = 0;
+
+    for length in lengths {
+        h.reset();
+        values.clear();
+
+        for v in RandomMaxIter::new(&mut rng).take(length) {
+            h.record(v).unwrap();
+            values.push(v);
+        }
+
+        values.sort();
+
+        assert_eq!(length as u64, h.count());
+
+        for (index, &v) in values.iter().enumerate() {
+            let quantile = (Rational::from(Integer::from(index as u64 + 1))
+                    / Rational::from(Integer::from(length as u64))).to_f64();
+            let calculated_value = h.value_at_quantile(quantile);
+            if !h.equivalent(v, calculated_value) {
+                errors += 1;
+                println!("len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
+                         length, index, quantile, quantile * length as f64, v, h.highest_equivalent(v),
+                         calculated_value, h.highest_equivalent(calculated_value));
+            }
+        }
+    }
+
+    assert_eq!(0, errors);
+}
+
+#[test]
+fn value_at_quantile_matches_random_quantile_random_values() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+    let mut values = Vec::new();
+
+    let lengths = vec![1, 5, 10, 50, 100, 500, 1_000, 5_000, 10_000];
+
+    let mut rng = rand::thread_rng();
+    let quantile_range = Range::new(0_f64, 1_f64.next());
+
+    let mut errors: u64 = 0;
+
+    for length in lengths {
+        h.reset();
+        values.clear();
+
+        for v in RandomMaxIter::new(&mut rng).take(length) {
+            h.record(v).unwrap();
+            values.push(v);
+        }
+
+        values.sort();
+
+        assert_eq!(length as u64, h.count());
+
+        for _ in 0..1_000 {
+            let quantile = quantile_range.ind_sample(&mut rng);
+            let index_at_quantile = (Rational::from_f64(quantile).unwrap()
+                    * Rational::from(Integer::from(length as u64)))
+                    .to_integer().to_u64().unwrap() as usize;
+            let calculated_value = h.value_at_quantile(quantile);
+            let v = values[index_at_quantile];
+            if !h.equivalent(v, calculated_value) {
+                errors += 1;
+                println!("len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
+                         length, index_at_quantile, quantile, quantile * length as f64, v, h.highest_equivalent(v),
+                         calculated_value, h.highest_equivalent(calculated_value));
+            }
+        }
+    }
+
+    assert_eq!(0, errors);
+}
+
+/// An iterator of random `u64`s where the maximum value for each random number generation is picked
+/// from a uniform distribution of the 64 possible bit lengths for a `u64`.
+///
+/// This helps create somewhat more realistic distributions of numbers. A simple random u64 is very
+/// likely to be a HUGE number; this helps scatter some numbers down in the smaller end.
+struct RandomMaxIter<'a, R: Rng + 'a> {
+    rng: &'a mut R
+}
+
+impl<'a, R: Rng + 'a> RandomMaxIter<'a, R> {
+    fn new(rng: &'a mut R) -> RandomMaxIter<R> {
+        RandomMaxIter {
+            rng
+        }
+    }
+}
+
+impl<'a, R: Rng + 'a> Iterator for RandomMaxIter<'a, R> {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let bit_length = self.rng.gen_range(0, 65);
+
+        return Some(match bit_length {
+            0 => 0,
+            64 => u64::max_value(),
+            x => self.rng.gen_range(0, 1 << x)
+        });
+    }
+}
+
+/// Calculate the count at a quantile with arbitrary precision arithmetic
+fn calculate_quantile_count(quantile: f64, count: u64) -> u64 {
+    let product = Rational::from_f64(quantile).unwrap() * Rational::from(Integer::from(count));
+    let prod_as_int = (product).to_integer();
+
+    // emulate ceil()
+    if product == Rational::from(prod_as_int.clone()) {
+        return prod_as_int.to_u64().unwrap();
+    } else {
+        // to_integer()'s rounding down has chopped off a fractional part
+        return prod_as_int.to_u64().unwrap() + 1;
+    }
+}
+
+
+fn next_value_nonzero_count<C: Counter>(h: &Histogram<C>, start_value: u64) -> u64 {
+    let mut v = h.next_non_equivalent(start_value);
+
+    loop {
+        if h.count_at(v) > C::zero() {
+            return h.highest_equivalent(v);
+        }
+
+        v = h.next_non_equivalent(v);
+    }
+}
+
+
+fn prev_value_nonzero_count<C: Counter>(h: &Histogram<C>, start_value: u64) -> u64 {
+    let mut v = h.lowest_equivalent(start_value).saturating_sub(1);
+
+    loop {
+        if v == 0 {
+            return 0;
+        }
+
+        if h.count_at(v) > C::zero() {
+            return h.highest_equivalent(v);
+        }
+
+        v = h.lowest_equivalent(v).saturating_sub(1);
+    }
+}

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -3,13 +3,13 @@ extern crate ieee754;
 extern crate rand;
 extern crate rug;
 
-use hdrsample::{Histogram, Counter};
+use hdrsample::{Counter, Histogram};
 
 use rand::Rng;
 use rand::distributions::range::Range;
 use rand::distributions::IndependentSample;
 use ieee754::Ieee754;
-use rug::{Rational, Integer};
+use rug::{Integer, Rational};
 
 #[test]
 fn value_at_quantile_internal_count_exceeds_bucket_type() {
@@ -118,15 +118,22 @@ fn value_at_quantile_matches_quantile_iter_sequence_values() {
             // artifacts, so this test will frequently fail if you expect the actual value to
             // match the calculated value. Instead, we allow it to be one bucket high or low.
 
-            if calculated_value != v
-                    && calculated_value != prev_value_nonzero_count(&h, v)
-                    && calculated_value != next_value_nonzero_count(&h, v) {
+            if calculated_value != v && calculated_value != prev_value_nonzero_count(&h, v)
+                && calculated_value != next_value_nonzero_count(&h, v)
+            {
                 let q_count_rational = calculate_quantile_count(iter_val.quantile(), length);
 
-                println!("len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
-                         length, iter_val.quantile(), iter_val.quantile() * length as f64,
-                         q_count_rational, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
+                println!(
+                    "len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
+                    length,
+                    iter_val.quantile(),
+                    iter_val.quantile() * length as f64,
+                    q_count_rational,
+                    v,
+                    h.highest_equivalent(v),
+                    calculated_value,
+                    h.highest_equivalent(calculated_value)
+                );
                 errors += 1;
             }
         }
@@ -165,15 +172,22 @@ fn value_at_quantile_matches_quantile_iter_random_values() {
             // artifacts, so this test will frequently fail if you expect the actual value to
             // match the calculated value. Instead, we allow it to be one bucket high or low.
 
-            if calculated_value != v
-                    && calculated_value != prev_value_nonzero_count(&h, v)
-                    && calculated_value != next_value_nonzero_count(&h, v) {
+            if calculated_value != v && calculated_value != prev_value_nonzero_count(&h, v)
+                && calculated_value != next_value_nonzero_count(&h, v)
+            {
                 let q_count_rational = calculate_quantile_count(iter_val.quantile(), length as u64);
 
-                println!("len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
-                         length, iter_val.quantile(), iter_val.quantile() * length as f64,
-                         q_count_rational, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
+                println!(
+                    "len {} iter quantile {} q * count fp {} q count rational {} iter val {} -> {} calc val {} -> {}",
+                    length,
+                    iter_val.quantile(),
+                    iter_val.quantile() * length as f64,
+                    q_count_rational,
+                    v,
+                    h.highest_equivalent(v),
+                    calculated_value,
+                    h.highest_equivalent(calculated_value)
+                );
                 errors += 1;
             }
         }
@@ -200,13 +214,21 @@ fn value_at_quantile_matches_quantile_at_each_value_sequence_values() {
 
         for v in 1..(length + 1) {
             let quantile = (Rational::from(Integer::from(v as u64))
-                    / Rational::from(Integer::from(length as u64))).to_f64();
+                / Rational::from(Integer::from(length as u64)))
+                .to_f64();
             let calculated_value = h.value_at_quantile(quantile);
             if !h.equivalent(v, calculated_value) {
-                println!("len {} value {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
-                         length, v, quantile, quantile * length as f64,
-                         v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
+                println!(
+                    "len {} value {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
+                    length,
+                    v,
+                    quantile,
+                    quantile * length as f64,
+                    v,
+                    h.highest_equivalent(v),
+                    calculated_value,
+                    h.highest_equivalent(calculated_value)
+                );
                 errors += 1;
             }
         }
@@ -241,13 +263,22 @@ fn value_at_quantile_matches_quantile_at_each_value_random_values() {
 
         for (index, &v) in values.iter().enumerate() {
             let quantile = (Rational::from(Integer::from(index as u64 + 1))
-                    / Rational::from(Integer::from(length as u64))).to_f64();
+                / Rational::from(Integer::from(length as u64)))
+                .to_f64();
             let calculated_value = h.value_at_quantile(quantile);
             if !h.equivalent(v, calculated_value) {
                 errors += 1;
-                println!("len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
-                         length, index, quantile, quantile * length as f64, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
+                println!(
+                    "len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
+                    length,
+                    index,
+                    quantile,
+                    quantile * length as f64,
+                    v,
+                    h.highest_equivalent(v),
+                    calculated_value,
+                    h.highest_equivalent(calculated_value)
+                );
             }
         }
     }
@@ -283,15 +314,25 @@ fn value_at_quantile_matches_random_quantile_random_values() {
         for _ in 0..1_000 {
             let quantile = quantile_range.ind_sample(&mut rng);
             let index_at_quantile = (Rational::from_f64(quantile).unwrap()
-                    * Rational::from(Integer::from(length as u64)))
-                    .to_integer().to_u64().unwrap() as usize;
+                * Rational::from(Integer::from(length as u64)))
+                .to_integer()
+                .to_u64()
+                .unwrap() as usize;
             let calculated_value = h.value_at_quantile(quantile);
             let v = values[index_at_quantile];
             if !h.equivalent(v, calculated_value) {
                 errors += 1;
-                println!("len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
-                         length, index_at_quantile, quantile, quantile * length as f64, v, h.highest_equivalent(v),
-                         calculated_value, h.highest_equivalent(calculated_value));
+                println!(
+                    "len {} index {} quantile {} q * count fp {} actual {} -> {} calc {} -> {}",
+                    length,
+                    index_at_quantile,
+                    quantile,
+                    quantile * length as f64,
+                    v,
+                    h.highest_equivalent(v),
+                    calculated_value,
+                    h.highest_equivalent(calculated_value)
+                );
             }
         }
     }
@@ -305,14 +346,12 @@ fn value_at_quantile_matches_random_quantile_random_values() {
 /// This helps create somewhat more realistic distributions of numbers. A simple random u64 is very
 /// likely to be a HUGE number; this helps scatter some numbers down in the smaller end.
 struct RandomMaxIter<'a, R: Rng + 'a> {
-    rng: &'a mut R
+    rng: &'a mut R,
 }
 
 impl<'a, R: Rng + 'a> RandomMaxIter<'a, R> {
     fn new(rng: &'a mut R) -> RandomMaxIter<R> {
-        RandomMaxIter {
-            rng
-        }
+        RandomMaxIter { rng }
     }
 }
 
@@ -325,7 +364,7 @@ impl<'a, R: Rng + 'a> Iterator for RandomMaxIter<'a, R> {
         return Some(match bit_length {
             0 => 0,
             64 => u64::max_value(),
-            x => self.rng.gen_range(0, 1 << x)
+            x => self.rng.gen_range(0, 1 << x),
         });
     }
 }

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -110,7 +110,7 @@ fn value_at_quantile_matches_quantile_iter_sequence_values() {
 
         for iter_val in iter {
             let calculated_value = h.value_at_quantile(iter_val.quantile());
-            let v = iter_val.value();
+            let v = iter_val.value_iterated_to();
 
             // Quantile iteration has problematic floating-point calculations. Calculating the
             // quantile involves something like `index / total_count`, and that's then multiplied
@@ -157,7 +157,7 @@ fn value_at_quantile_matches_quantile_iter_random_values() {
 
         for iter_val in iter {
             let calculated_value = h.value_at_quantile(iter_val.quantile());
-            let v = iter_val.value();
+            let v = iter_val.value_iterated_to();
 
             // Quantile iteration has problematic floating-point calculations. Calculating the
             // quantile involves something like `index / total_count`, and that's then multiplied


### PR DESCRIPTION
Incorporating a gaggle of smaller fixes I came upon while working on this:

- Iteration now stops when the index with the max value is reached rather than going by total count. This avoids stopping too early when total count saturates (fixes #47, and a few parts of #38). Count since last iteration is also started from 0 at each iteration point, making it less prone to overflow.
- Linear iteration was stopping one iteration too soon in some cases due to a subtle off-by-one.
- Quantile iteration now skips straight to quantile 1.0 if it reaches the index with the max value, just like the Java impl. See long-winded comments, and even more long-winded tests.
- Rather than having pickers provide accessors for metadata about what was just picked, have `pick()` return a metadata struct with optional fields so that the timeline is clear and pickers don't need mostly useless fields to hang on to data until it can be requested 1 function call later.
- Ported iteration tests from the old rust implementation.
