### PR TITLE
update rug to 0.9, and use rug more idiomatically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ base64 = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 rand = "0.3.15"
-rug = "0.6.0"
+rug = "0.9.1"
 ieee754 = "0.2.2"
 clap = "2.26.2"
 


### PR DESCRIPTION
This commit:

* updates the rug dependency to the latest version
* only uses the required features of rug to save rug compilation time as it doesn't have to compile the float and complex libraries
* uses rug more idiomatically